### PR TITLE
Add script to time endpoints.

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -14,6 +14,7 @@ api
 ├── endpoints/          Specifies groups of endpoints for the API.
 ├── metrics/            Implementations of metrics.
 ├── questions/          Implementations of questions.
+├── scripts/            Scripts for tasks.
 ├── utils/              Helper functions.
 ├── __init__.py         File that tells Python that this folder is a module, also exports the Flask app.
 ├── README.txt          (This file!) Helps explain the backend API.

--- a/api/scripts/time_endpoints.py
+++ b/api/scripts/time_endpoints.py
@@ -1,0 +1,84 @@
+import json
+import requests
+from timeit import default_timer as timer
+
+API = "http://localhost:5000"
+
+
+def time_get_endpoint(endpoint):
+    print(f"GET {endpoint}")
+    start = timer()
+    r = requests.get(f"{API}{endpoint}")
+    r.json()
+    secs = timer() - start
+    b = len(r.content) 
+    print(f"\tgot {b:d} bytes")
+    print(f"\tin {secs:.1f} secs")
+    print()
+
+def time_post_endpoint(endpoint, body):
+    print(f"POST {endpoint}")
+    start = timer()
+    r = requests.post(
+        f"{API}{endpoint}",
+        data=json.dumps(body),
+        headers={
+            "Content-Type": "application/json"
+        }
+    )
+    r.json()
+    secs = timer() - start
+    b = len(r.content) 
+    print(f"\tgot {b:d} bytes")
+    print(f"\tin {secs:.1f} secs")
+    print()
+
+
+tables = [
+    "community_area",
+    "covid_spread",
+    "income",
+    "population",
+    "rideshare"  
+]
+
+count_endpoints = [ f"/count/{table}" for table in tables ]
+
+data_endpoints = [
+    "/rideshare/max_trips",
+    "/question/pooled_trips"
+]
+
+get_endpoints = count_endpoints + data_endpoints
+
+request_endpoints = [
+    (
+        "Metrics By Area: rideshare pickups since COVID + 2019 pooled trip rate",
+        "/community/metrics",
+        {
+            "metrics": [
+                "rideshare_pickups_covid",
+                "rideshare_pooled_trip_rate_2019"
+            ]
+        }
+    ),
+    (
+        "Metrics By Week: all rideshare pickups + all avg. cost",
+        "/weekly/metrics",
+        {
+            "metrics": [
+                "weekly_rideshare_pickups",
+                "weekly_rideshare_avg_cost"
+            ]
+        }
+    )
+]
+
+post_endpoints = request_endpoints
+
+for endpoint in get_endpoints:
+    time_get_endpoint(endpoint)
+
+for name, endpoint, body in post_endpoints:
+    print(name)
+    time_post_endpoint(endpoint, body)

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Guides to explain the layout of the codebase and common commands for working wit
 - [Add a New Endpoint](new_endpoint.md)
 - [Flask](flask.md)
 - [Write SQL Queries (Coming Soon)](sqlite.md#write-queries)
+- [Time API Requests](time_api_requests.md)
 
 #### Pipeline
 

--- a/docs/time_api_requests.md
+++ b/docs/time_api_requests.md
@@ -1,0 +1,64 @@
+# Time API Requests
+
+## Use Cases
+
+Here are some common cases when you may want to time API requests:
+
+- To get an estimate of how long new endpoint(s) take to return a response
+- To compare the change in response time of endpoint(s) that were modified
+- To identify areas for improvement in the response time of our API
+
+## Instructions
+
+1. Modify `api/scripts/time_endpoints.py` to include the requests you want to time.
+2. Change directories to be in the root folder of the project.
+3. If your virtual environment is not active, activate it:
+
+```bash
+source .venv/bin/activate
+```
+
+4. Start a local API server to send the requests to.
+
+```bash
+FLASK_APP=api/server.py FLASK_DEBUG=1 FLASK_ENV=development flask run
+```
+
+5. Run the script to get the results.
+
+```bash
+# This command will show results in your terminal:
+python3 api/scripts/time_endpoints.py
+```
+
+```bash
+# Alternatively, this command will write results to a file:
+python3 api/scripts/time_endpoints.py > results.txt
+```
+
+6. Copy the results to include in your pull request or doc.
+7. If you wrote results to a file, delete or gitignore that file
+
+## Comparison
+
+If you are trying to compare the response time of a request before and after a change, you will need to follow the above instructions twice. Once for the state of the code and data before the change and once after the change. You might switch between different branches or different commits to do this.
+
+Remember to run these commands to unpack the version of the database for the branch or commit you are on:
+
+```bash
+cd pipeline
+make uncompressed
+cd ..
+```
+
+## Caveats
+
+There are several reasons why these results may not be good estimates of how long a request will take in production:
+
+- This script only runs each request once to time it
+- The server is running locally on your machine
+    - Request transit time is likely lower
+    - Resources on your machine may differ from our production server
+    - No simulated load, the script is probably the only client sending requests to the local server
+- This timing includes sending, receiving, and parsing the request
+    - May not include time needed to process and render the data on the frontend


### PR DESCRIPTION
Added script and documentation. More could be done to make this convenient for developers (or perhaps it would be better to use an established tool for request timing or even load testing), but I think that could make a good extra engineering task for one of the students.