### PR TITLE
Add server loading notification.

### DIFF
--- a/app/components/Notification.js
+++ b/app/components/Notification.js
@@ -1,0 +1,111 @@
+import { useState, useEffect } from 'react'
+
+export function Notification(props) {
+  // By default, notification is hidden until set to visible.
+  const [ isVisible, setIsVisible ] = useState(props.visible || false);
+  const classes = props.classes || [];
+  const display = isVisible ? "block" : "hidden";
+
+  useEffect(() => {
+    setIsVisible(props.visible);
+  }, [props.visible]);
+
+  return (
+    <div className={`Notification ${classes.join(" ")} ${display}`}>
+      <span
+        className="Close"
+        onClick={() => {
+          setIsVisible(false);
+        }}
+        >x</span>
+      {props.children}
+    </div>
+  );
+};
+
+/*
+ * Send a request to wake up our server.
+ * Return a promise that always resolves, even if there is a failure.
+ * Will resolve with true if success, false if failure.
+ */
+async function pingServer() {
+  return new Promise((resolve, reject) => {
+    fetch(`${process.env.NEXT_PUBLIC_API}/`).then((res) => {
+      resolve(true);
+    }).catch((err) => {
+    resolve(false);
+    });
+  });
+}
+
+const LOCAL_STORAGE_LAST_PING = "transithealth__last_ping";
+const WAIT_MS_BEFORE_NEXT_PING = 1000 * 60 * 5; // 5 mins in ms
+
+const SERVER_MESSAGES = {
+  LOADING: "Connecting to our server...",
+  SUCCESS: "Connected successfully!",
+  FAILURE: "Could not connect. Please reload page.",
+};
+
+export function ServerLoadingNotification() {
+  const [ isLoading, setIsLoading ] = useState(true);
+  const [ isSuccess, setIsSuccess ] = useState(true);
+  const [ isVisible, setIsVisible ] = useState(false);
+
+  useEffect(() => {
+    let isSubscribed = true;
+    let openTimer, closeTimer;
+
+    // Only send ping if ping has not been sent recently.
+    const lastPing = localStorage.getItem(LOCAL_STORAGE_LAST_PING);
+    const sendPing = !lastPing || (Date.now() - lastPing) >= WAIT_MS_BEFORE_NEXT_PING;
+
+    if (sendPing) {
+      openTimer = setTimeout(() => {
+        if (isSubscribed) {
+          setIsVisible(true);
+        }
+      }, 1000);
+      pingServer().then((success) => {
+        if (isSubscribed) {
+          setIsSuccess(success);
+          setIsLoading(false);
+        }
+        // If successful, close notification after one second.
+        if (success) {
+          localStorage.setItem(LOCAL_STORAGE_LAST_PING, Date.now());
+          closeTimer = setTimeout(() => {
+            if (isSubscribed) {
+              setIsVisible(false);
+            }
+          }, 1000);
+        }
+      });
+    }
+
+    return () => {
+      isSubscribed = false;
+      if (openTimer) {
+        clearTimeout(openTimer);
+      }
+      if (closeTimer) {
+        clearTimeout(closeTimer);
+      }
+    };
+  }, []);
+
+  const outcome = isLoading ? "" : (isSuccess ? "Success" : "Failure");
+  const animation = !isLoading && isSuccess ? "FadeOut" : "FadeIn";
+  const classes = [ "Bottom", "Narrow", outcome, animation ];
+  const message = isLoading ? SERVER_MESSAGES.LOADING : (
+      isSuccess ? SERVER_MESSAGES.SUCCESS : SERVER_MESSAGES.FAILURE
+    );
+
+  return (
+    <div>
+      <Notification classes={classes} visible={isVisible}>
+        <p>{message}</p>
+      </Notification>
+    </div>
+  );
+};

--- a/app/pages/about.js
+++ b/app/pages/about.js
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import Nav from '../components/Nav'
+import { ServerLoadingNotification } from '../components/Notification'
 
 export default function About() {
   return (
@@ -17,6 +18,7 @@ export default function About() {
           <p>TransitHealth is developed by students at Scarlet Data Studio.</p>
         </div>
       </main>
+      <ServerLoadingNotification />
     </div>
   )
 }

--- a/app/pages/explorer.js
+++ b/app/pages/explorer.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Nav from '../components/Nav'
+import { ServerLoadingNotification } from '../components/Notification'
 
 export default function Explorer() {
   return (
@@ -48,6 +49,7 @@ export default function Explorer() {
           </div>
         </div>
       </main>
+      <ServerLoadingNotification />
     </div>
   );
 }

--- a/app/pages/index.js
+++ b/app/pages/index.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import Head from 'next/head'
 import Nav from '../components/Nav'
 import HomeDemo from '../components/HomeDemo'
+import { ServerLoadingNotification } from '../components/Notification'
 
 export async function getStaticProps() {
   const communityAreas = JSON.parse(fs.readFileSync(
@@ -34,6 +35,7 @@ export default function Home({ communityAreas }) {
           <HomeDemo communityAreas={communityAreas} />
         </div>
       </main>
+      <ServerLoadingNotification />
     </div>
   )
 }

--- a/app/pages/questions.js
+++ b/app/pages/questions.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 import Nav from '../components/Nav'
 import { getAllQuestions } from '../site/questions'
+import { ServerLoadingNotification } from '../components/Notification'
 
 export async function getStaticProps() {
   return {
@@ -46,6 +47,7 @@ export default function Questions({ questions }) {
           <p className="center">That's all for now! More questions coming soon...</p>
         </div>
       </main>
+      <ServerLoadingNotification />
     </div>
   )
 }

--- a/app/pages/questions/[id].js
+++ b/app/pages/questions/[id].js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Nav from '../../components/Nav'
+import { ServerLoadingNotification } from '../../components/Notification'
 import { useState } from 'react'
 import {
   questionComponents,
@@ -48,6 +49,7 @@ export default function Question(props) {
           <br />
         </div>
       </main>
+      <ServerLoadingNotification />
     </div>
   );
 }

--- a/app/pages/scatter.js
+++ b/app/pages/scatter.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import Head from 'next/head'
 import Nav from '../components/Nav'
 import CommunityScatterExplorer from '../components/CommunityScatterExplorer'
+import { ServerLoadingNotification } from '../components/Notification'
 
 export async function getStaticProps() {
   const communityAreas = JSON.parse(fs.readFileSync(
@@ -34,6 +35,7 @@ export default function ScatterView({ communityAreas }) {
           <CommunityScatterExplorer communityAreas={communityAreas} />
         </div>
       </main>
+      <ServerLoadingNotification />
     </div>
   );
 }

--- a/app/pages/timeline.js
+++ b/app/pages/timeline.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Nav from '../components/Nav'
 import TimelineExplorer from '../components/TimelineExplorer'
 import { timelineExplorerDefaults } from '../site/metrics'
+import { ServerLoadingNotification } from '../components/Notification'
 
 export default function TimelineView() {
   return (
@@ -23,6 +24,7 @@ export default function TimelineView() {
           <TimelineExplorer metrics={timelineExplorerDefaults.defaultMetrics} />
         </div>
       </main>
+      <ServerLoadingNotification />
     </div>
   );
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -9,6 +9,8 @@
     --color-empty: var(--color-light-gray);
     --color-data: var(--color-main);
     --color-highlight: var(--color-accent);
+    --color-success: rgb(9, 145, 120);
+    --color-failure: rgb(204, 102, 119);
 }
 
 html {
@@ -391,6 +393,99 @@ a.btn {
 
 .TableContainer .Sorted .SortArrow {
     display: inline;
+}
+
+/* Notifications */
+
+.Notification {
+    background: white;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+    margin: 1em;
+    padding: 0.25em;
+}
+
+.Notification.Narrow {
+    width: 200px;
+}
+
+.Notification.Wide {
+    width: 650px;
+}
+
+@media screen and (max-width: 350px) {
+    
+    .Notification {
+        width: 200px;
+    }
+
+}
+
+.Notification .Close {
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+    opacity: 0.5;
+}
+
+.Notification .Close:hover {
+    cursor: pointer;
+    opacity: 1.0;
+}
+
+.Notification.Bottom {
+    position: absolute;
+    left: 50%;
+    bottom: 1em;
+    transform: translate(-50%, -50%);
+    margin: 0;
+}
+
+.Notification.hidden {
+    opacity: 0;
+}
+
+.Notification.Success {
+    border: 1px solid var(--color-success);
+}
+
+.Notification.Failure {
+    border: 1px solid var(--color-failure);
+}
+
+@keyframes FadeOut {
+    0% { opacity: 1; }
+    99% { opacity: 0.01; }
+    100% { opacity: 0; }
+}
+
+@-webkit-keyframes FadeOut {
+    0% { opacity: 1; }
+    99% { opacity: 0.01; }
+    100% { opacity: 0; }
+}
+
+@keyframes FadeIn {
+    0% { opacity: 0; }
+    99% { opacity: 0.99; }
+    100% { opacity: 1; }
+}
+
+@-webkit-keyframes FadeIn {
+    0% { opacity: 0; }
+    99% { opacity: 0.99; }
+    100% { opacity: 1; }
+}
+
+.Notification.FadeOut {
+    animation: FadeOut 1s;
+    -webkit-animation: FadeOut 1s;
+    animation-fill-mode: forwards;
+}
+
+.Notification.FadeIn {
+    animation: FadeIn 1s;
+    -webkit-animation: FadeIn 1s;
+    animation-fill-mode: forwards;
 }
 
 /* Questions Page */


### PR DESCRIPTION
We use the Heroku free tier, so if our server does not receive any requests for some time, it will shut down. If it receives another request, it has to wake back up and run all the initialization code before responding to a request.

To help show progress to visitors (and so that they don't think the website is broken), I added a notification to show that the site is connecting to our server. This also sends a request to the server to wake it up. This runs on every page. This wake up request will not be sent if one was sent from this browser within the last five minutes.

Check out this video for a demo. I added a `time.sleep(5)` call to the endpoints to simulate a 5 second wake up time.

https://www.loom.com/share/13c4ca51f4434796983be9077d9ed743