### PR TITLE
Add Makefile targets for working with archives of large files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ app/transithealth/
 
 pipeline/data/*
 pipeline/database.db
+pipeline/archive.tgz
 
 # End of project-specific ignores.
 

--- a/docs/pages/makefiles.md
+++ b/docs/pages/makefiles.md
@@ -99,10 +99,42 @@ make clean-except && make
 
 You can use `clean-except` to clean all files except for some files we have given exceptions to. The exceptions are specified in the target, and they must satisfy two criteria:
 
-1. They have no dependencies
-2. They take a long time to make
+1. They take a long time to make
+2. AND they have no dependencies (OR their dependencies also have exceptions)
 
 Currently, the only datasets that we want to make exceptions for are the rideshare and taxi trips datasets, since they are the largest datasets we will extract.
+
+## Complete Run with Archive
+
+We keep a compressed archive of the files that have exceptions, so that we can download and unpack the results instead of making them from scratch.
+
+You can download the latest archive from this Drive link:
+
+```
+https://drive.google.com/file/d/1UG0G8PemaT1YU_BKaOfN-PIq191KvceV/view?usp=sharing
+```
+
+Download the file and move it to `pipeline/archive.tgz`. Then unpack its contents.
+
+```bash
+make unpack-archive
+```
+
+As long as you have `pipeline/archive.tgz`, you can rerun the entire pipeline, without remaking the files with exceptions, using this command:
+
+```bash
+make clean && make unpack-archive && make
+```
+
+After the archive is unpacked, you can use the command for a [complete run with exceptions](#complete-run-with-exceptions) from then on.
+
+If you change any of the files that have exceptions, then you should create a new archive.
+
+```bash
+make archive.tgz
+```
+
+Then upload `archive.tgz` to a location where others can get it and mark it as the latest archive version (ask Vinesh for help with this).
 
 ## Writing Makefiles
 

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -191,18 +191,40 @@ Run this command to unpack the compressed database into a file that the backend 
 make uncompressed
 ```
 
-Running the entire offline pipeline from scratch can take a while. You can skip this step for now:
+### Optional: Run the Pipeline
 
-```bash
-# This will delete the database and run the entire database from scratch, which can take a long time
-make clean && make
+If you would like to run the entire pipeline (except for the files that take the longest to make), then follow these steps. Otherwise, skip to [the next heading](#verify-database).
+
+First, download the latest archive from this Drive link. This contains the files that take the longest to make.
+
+```
+https://drive.google.com/file/d/1UG0G8PemaT1YU_BKaOfN-PIq191KvceV/view?usp=sharing
 ```
 
-After unpacking the compressed database, go back up to the project root directory.
+Download the file and move it to `pipeline/archive.tgz`. Then unpack its contents using this command:
+
+```bash
+make unpack-archive
+```
+
+Now you can run the rest of the pipeline. This command will clear all files except the ones from the archive and then rerun the entire pipeline:
+
+```bash
+make clean-except && make
+```
+
+### Verify Database
+
+Now that you have unpacked the database, you can run basic tests to check its contents.
+
+First, go back up to the project root directory. Then, run our unit testing command `pytest`. This will run all unit tests for the project.
 
 ```bash
 cd ..
+pytest
 ```
+
+If you get a message that all tests are passing, you are good to go! Otherwise, ask for help.
 
 ## 7. Run Backend API
 

--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -175,6 +175,28 @@ resources:
 		--input_file="data/transformed/community_area.csv" \
 		--output_file="../app/public/resources/community_area.json"
 
+# Archive for files that take a long time to make
+
+archive.tgz: data/transformed/rideshare.csv data/extracted/daily_rideshare.csv
+	mkdir archive
+	mkdir archive/extracted
+	mkdir archive/transformed
+	cp data/extracted/daily_rideshare.csv archive/extracted/daily_rideshare.csv
+	cp data/transformed/rideshare.csv archive/transformed/rideshare.csv
+	tar cfz archive.tgz archive/
+	rm -rf archive
+
+unpack-archive:
+	rm -rf archive
+	tar -xvf archive.tgz
+	cp archive/extracted/daily_rideshare.csv data/extracted/daily_rideshare.csv
+	cp archive/transformed/rideshare.csv data/transformed/rideshare.csv
+	rm -rf archive
+
+clean-archive:
+	rm -rf data/archive
+	rm -f archive.tgz
+
 # Clean
 
 clean:
@@ -193,10 +215,15 @@ clean-resources:
 clean-except:
 	# Runs make clean on all files except those specified here
 	# Gives you a quicker version of clean, use only if your change does not impact these files
-	# Exceptions are meant for files that (a) have no dependencies and (b) take a long time to make
+	# Exceptions are meant for files that:
+	# - (a) take a long time to make
+	# - (b) AND have no dependencies (OR their dependencies also have exceptions)
 	mkdir tempdata
 	mkdir tempdata/extracted
+	mkdir tempdata/transformed
 	cp data/extracted/daily_rideshare.csv tempdata/extracted/daily_rideshare.csv
+	cp data/transformed/rideshare.csv tempdata/transformed/rideshare.csv
 	make clean
 	cp tempdata/extracted/daily_rideshare.csv data/extracted/daily_rideshare.csv
+	cp tempdata/transformed/rideshare.csv data/transformed/rideshare.csv
 	rm -rf tempdata


### PR DESCRIPTION
This change will allow developers to skip extracting and transforming rideshare data, which can more than 10 minutes. Later we may use the same process for the taxi data.

This pull request also updates the documentation on how to work with these data archives.

Testing on a remote machine to confirm this works. It works! ✅ 

Caveats:
- We should try to keep the archive size under 100MB, that way we stay below the limits to upload it to cloud-based IDEs.
- Google Drive does not allow automated downloads for files this large, so you have to manually download the archive.
- These Make commands will work for Windows users who followed the setup instructions (installed Cygwin and installed Make via Chocolatey).