### PR TITLE
Add command to run SQLite CLI.

### DIFF
--- a/docs/pages/commands.md
+++ b/docs/pages/commands.md
@@ -14,6 +14,7 @@
 | `run db` | Get the latest database from the compressed files. |
 | `run tests` | Run all tests. |
 | `run notebooks 9` | Run the Jupyter notebook server. |
+| `run sqlite` | Run the SQLite command line interface. |
 | `run update` | Update dependencies. |
 
 ## Offline Pipeline

--- a/docs/pages/sqlite.md
+++ b/docs/pages/sqlite.md
@@ -73,19 +73,11 @@ The `sqlite3` command line interface allows you to check a database an run queri
 
 ### Example Usage
 
-Run these commands in your terminal:
+Run these commands in your terminal. You can do this from the `transithealth/` or `pipeline/` directories, either works.
 
 ```bash
-# Change to the pipeline/ directory if you are not already there
-cd pipeline
 # Start an interactive sqlite3 session in your terminal
-sqlite3
-# Connect to our database
-.open database.db
-# Set sqlite3 to show column headers with output
-.headers on
-# List all the tables
-.tables
+run sqlite
 # Show the schema of a table
 .schema TABLE_NAME
 # Show all columns for the first five rows of a table

--- a/run.sh
+++ b/run.sh
@@ -76,3 +76,15 @@ if [ "$1" == "notebooks" ]; then
   echo "./notebooks/start.sh $2"
   ./notebooks/start.sh "$2"
 fi
+
+# Start SQLite command line interface
+if [ "$1" == "sqlite" ]; then
+  echo "Starting SQLite command line interface..."
+  # If in the pipeline folder, go back up
+  # So that this command can be run from either transithealth/ or pipeline/
+  CURRENT_DIR=$(basename $(pwd))
+  if [ "$CURRENT_DIR" == "pipeline" ]; then
+    cd ..
+  fi
+  sqlite3 pipeline/database.db -header --column
+fi


### PR DESCRIPTION
Context: https://scarletdatastudio.slack.com/archives/C0253HKGP5J/p1626131579008200

- We have sqlite 3.7, which does not support the `.open` command.
- Our whole team is using Python 3.7 on Cloud9.
- The sqlite module comes with Python, ~so if we want sqlite 3.8, we would have to upgrade to Python 3.8.~ (actually, we could install sqlite 3.8 directly and add it to the `requirements.txt`)
- @fabrego524 found a fix: using `sqlite <path_to_db>` to start a session.

For now, I think it would be easiest to use this fix, especially since Python and sqlite 3.7 are supported.

I also took this opportunity to add the `-header -column` flags, which make the query output easier to read.

I have added a `run sqlite` command that will start the CLI, which should be easier to remember.

Example usage:

```bashVineshKannan:~/environment/transithealth (run_sqlite) $ run sqlite
Starting SQLite command line interface...
SQLite version 3.7.17 2013-05-20 00:56:22
Enter ".help" for instructions
Enter SQL statements terminated with a ";"
sqlite> select * from income limit 5;
area_number  segment     value             std_error         period_start_year  period_end_year  period    
-----------  ----------  ----------------  ----------------  -----------------  ---------------  ----------
35           all         39315.5425143917  3339.54356496147  2015               2019             2015-2019 
36           all         32562.7874887729  4636.74618433015  2015               2019             2015-2019 
37           all         23154.3529608972  1485.72849371116  2015               2019             2015-2019 
38           all         36855.9261336099  2683.20881328964  2015               2019             2015-2019 
39           all         53210.7884583064  5218.27298455406  2015               2019             2015-2019 
sqlite> .exit
```

This command will work from both the `transithealth/` and `pipeline/` directories. I added a check for pipeline because that is where I expect most engineers will use it, while working on the pipeline with make.

```bash
VineshKannan:~/environment/transithealth (run_sqlite) $ cd pipeline
VineshKannan:~/environment/transithealth/pipeline (run_sqlite) $ run sqlite
Starting SQLite command line interface...
SQLite version 3.7.17 2013-05-20 00:56:22
Enter ".help" for instructions
Enter SQL statements terminated with a ";"
sqlite> select * from income limit 5;
area_number  segment     value             std_error         period_start_year  period_end_year  period    
-----------  ----------  ----------------  ----------------  -----------------  ---------------  ----------
35           all         39315.5425143917  3339.54356496147  2015               2019             2015-2019 
36           all         32562.7874887729  4636.74618433015  2015               2019             2015-2019 
37           all         23154.3529608972  1485.72849371116  2015               2019             2015-2019 
38           all         36855.9261336099  2683.20881328964  2015               2019             2015-2019 
39           all         53210.7884583064  5218.27298455406  2015               2019             2015-2019 
sqlite> .exit
```