### PR TITLE
Run command fixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,4 +41,4 @@ jobs:
           tar -xf compressed.db.tgz
           rm compressed.db.tgz
           cd ..
-          pytest -vv
+          pytest -vvl

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,13 +8,13 @@ on:
       - .github/workflows/test.yaml
       - requirements.txt
       - pytest.ini
-      - '*.py'
+      - '**.py'
   pull_request:
     paths:
       - .github/workflows/test.yaml
       - requirements.txt
       - pytest.ini
-      - '*.py'
+      - '**.py'
 
 jobs:
   test-pytest:

--- a/api/dev.sh
+++ b/api/dev.sh
@@ -9,6 +9,8 @@ pip3 install -r requirements.txt
 # Refresh IP address for Cloud9 instance
 if [ -n "$1" ]; then
     ./api/scripts/refresh.sh
+    INSTANCE_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
+    echo "Launching API To: http://$INSTANCE_IP:5000"
 fi
 
 # Start Flask development server

--- a/run.sh
+++ b/run.sh
@@ -3,82 +3,63 @@
 # Tells the script to exit if a command fails instead of continuing
 set -e
 
-# Start backend API
 if [ "$1" == "api" ]; then
   echo "Starting backend API..."
   echo "./api/dev.sh $2"
   ./api/dev.sh "$2"
-fi
-
-# Start frontend app
-if [ "$1" == "app" ]; then
+  
+elif [ "$1" == "app" ]; then
   echo "Starting frontend app..."
   echo "./app/dev.sh $2"
   ./app/dev.sh "$2"
-fi
-
-# Make uncompressed database
-if [ "$1" == "db" ]; then
+  
+elif [ "$1" == "db" ]; then
   echo "Making uncompressed database..."
   # Drop any local changes to the compressed database
   git restore pipeline/compressed/*
   source .venv/bin/activate
   cd pipeline
   make uncompressed
-fi
-
-# Run offline pipeline, only load steps
-if [ "$1" == "pipeline-load" ]; then
+  
+elif [ "$1" == "pipeline-load" ]; then
   echo "Running offline pipeline, only load steps..."
   source .venv/bin/activate
   cd pipeline
   make reload
-fi
-
-# Run offline pipeline, without remaking large files
-if [ "$1" == "pipeline-quick" ]; then
+  
+elif [ "$1" == "pipeline-quick" ]; then
   echo "Running offline pipeline, without remaking large files..."
   source .venv/bin/activate
   cd pipeline
   make clean-except
   make
-fi
-
-# Run offline pipeline, remaking all steps
-if [ "$1" == "pipeline-all" ]; then
+  
+elif [ "$1" == "pipeline-all" ]; then
   echo "Running offline pipeline, remaking all steps..."
   source .venv/bin/activate
   cd pipeline
   make clean
   make
-fi
 
-# Run tests
-if [ "$1" == "tests" ]; then
+elif [ "$1" == "tests" ]; then
   echo "Running tests..."
   source .venv/bin/activate
   pytest -vvl
-fi
 
-# Update dependencies
-if [ "$1" == "update" ]; then
+elif [ "$1" == "update" ]; then
   echo "Updating dependencies..."
   cd app
   yarn install
   cd ..
   source .venv/bin/activate
   pip3 install -r requirements.txt
-fi
 
-# Start Jupyter notebook server
-if [ "$1" == "notebooks" ]; then
+elif [ "$1" == "notebooks" ]; then
   echo "Starting Jupyter notebook server..."
   echo "./notebooks/start.sh $2"
   ./notebooks/start.sh "$2"
-fi
 
-# Start SQLite command line interface
-if [ "$1" == "sqlite" ]; then
+elif [ "$1" == "sqlite" ]; then
   echo "Starting SQLite command line interface..."
   # If in the pipeline folder, go back up
   # So that this command can be run from either transithealth/ or pipeline/
@@ -87,4 +68,9 @@ if [ "$1" == "sqlite" ]; then
     cd ..
   fi
   sqlite3 pipeline/database.db -header --column
+
+else
+  echo "No run shortcut found for: $1"
+  echo "Did you pull the latest version?"
+
 fi

--- a/run.sh
+++ b/run.sh
@@ -57,7 +57,7 @@ fi
 if [ "$1" == "tests" ]; then
   echo "Running tests..."
   source .venv/bin/activate
-  pytest
+  pytest -vvl
 fi
 
 # Update dependencies


### PR DESCRIPTION
- Added `-vvl` flags to `run tests` so developers can see the local variables and find out which values cause the test to fail
- Fix GitHub actions config to run unit tests if any Python file changes
- Added an `else` case with message if a developer types a run command that does not have a shortcut
- Added a message to `run api 9` to print the URL with the instance IP where the API is running