### PR TITLE
Integrate Belonging Metric with Endpoint and Config

### DIFF
--- a/api/endpoints/community.py
+++ b/api/endpoints/community.py
@@ -23,8 +23,8 @@ def make_blueprint(con):
         "median_income_2010": lambda: metric.income(year=2010, segment="all"),
         "median_income_2019": lambda: metric.income(year=2019, segment="all"),
         "total_covid_cases": lambda: metric.covid_spread_sum_by_area("cases_weekly"),
-        "rate_of_belonging_2017": lambda: metric.belonging(year=2017, segment="all"),
-        "rate_of_belonging_2018": lambda: metric.belonging(year=2018, segment="all")
+        "belonging_rate_2017": lambda: metric.belonging(year=2017, segment="all"),
+        "belonging_rate_2018": lambda: metric.belonging(year=2018, segment="all")
     }
 
 

--- a/api/endpoints/community.py
+++ b/api/endpoints/community.py
@@ -22,7 +22,9 @@ def make_blueprint(con):
         "total_population_2019": lambda: metric.population(year=2019, segment="all"),
         "median_income_2010": lambda: metric.income(year=2010, segment="all"),
         "median_income_2019": lambda: metric.income(year=2019, segment="all"),
-        "total_covid_cases": lambda: metric.covid_spread_sum_by_area("cases_weekly")
+        "total_covid_cases": lambda: metric.covid_spread_sum_by_area("cases_weekly"),
+        "rate_of_belonging_2017": lambda: metric.belonging(year=2017, segment="all"),
+        "rate_of_belonging_2018": lambda: metric.belonging(year=2018, segment="all")
     }
 
 

--- a/app/site/metrics.js
+++ b/app/site/metrics.js
@@ -83,6 +83,18 @@ export const communityMetrics = {
     format: Formatter.numberInThousands,
     fullFormat: Formatter.numberWithCommas,
   },
+  rate_of_belonging_2017: {
+    name: "2017 Rate of Belonging",
+    units: "of people",
+    format: Formatter.percentWithNoDecimal,
+    fullFormat: Formatter.percentWithOneDecimal,
+  },
+  rate_of_belonging_2018: {
+    name: "2018 Rate of Belonging",
+    units: "of people",
+    format: Formatter.percentWithNoDecimal,
+    fullFormat: Formatter.percentWithOneDecimal,
+  },
 };
 
 export const weeklyMetrics = {

--- a/app/site/metrics.js
+++ b/app/site/metrics.js
@@ -83,13 +83,13 @@ export const communityMetrics = {
     format: Formatter.numberInThousands,
     fullFormat: Formatter.numberWithCommas,
   },
-  rate_of_belonging_2017: {
+  belonging_rate_2017: {
     name: "2017 Rate of Belonging",
     units: "of people",
     format: Formatter.percentWithNoDecimal,
     fullFormat: Formatter.percentWithOneDecimal,
   },
-  rate_of_belonging_2018: {
+  belonging_rate_2018: {
     name: "2018 Rate of Belonging",
     units: "of people",
     format: Formatter.percentWithNoDecimal,


### PR DESCRIPTION
Added the Belonging Metric into the list of endpoints using existing conventions, one for 2017 and one for 2018. Also added the metrics into metrics.js with names and units. 