### PR TITLE
Fix community explorer to correctly show opacity when values are missing.

### DIFF
--- a/app/components/CommunityScatterExplorer.js
+++ b/app/components/CommunityScatterExplorer.js
@@ -39,9 +39,13 @@ async function getScatterMetrics(metricX, metricY) {
 }
 
 function getGeoMapMetric(metrics, selectedMetric, minAlpha=0.05) {
-  const maxVal = metrics.reduce((maxVal, val) => {
-    return Math.max(maxVal, val[selectedMetric]);
-  }, metrics[0][selectedMetric]);
+  const maxVal = metrics
+    // Exclude any records that do not have the metric
+    .filter(val => val[selectedMetric])
+    // Get the maximum value
+    .reduce((maxVal, val) => {
+      return Math.max(maxVal, val[selectedMetric]);
+    }, metrics[0][selectedMetric]);
   const metricMapData = metrics.reduce((agg, val) => {
     const alpha = val[selectedMetric] / maxVal;
     agg[val.area_number] = {

--- a/app/components/CommunityScatterExplorer.js
+++ b/app/components/CommunityScatterExplorer.js
@@ -47,7 +47,9 @@ function getGeoMapMetric(metrics, selectedMetric, minAlpha=0.05) {
       return Math.max(maxVal, val[selectedMetric]);
     }, metrics[0][selectedMetric]);
   const metricMapData = metrics.reduce((agg, val) => {
-    const alpha = val[selectedMetric] / maxVal;
+    // If record does not have metric, show zero opacity
+    const areaVal = val[selectedMetric] || 0;
+    const alpha = areaVal / maxVal;
     agg[val.area_number] = {
       ...val,
       opacity: Math.max(minAlpha, alpha),


### PR DESCRIPTION
Fabian's PR #44 exposed this bug in the community explorer component. If some community areas are missing data for the selected y-axis metric, then the opacity will be computed incorrectly, causing the Chicago map to show the same shade for all areas.

This PR fixes that bug:

- Filters out missing data when computing the max value
- Replaces missing data with zero when computing opacity

Here is a screenshot showing the fix applied to Fabian's branch:

<img width="1191" alt="Screen Shot 2021-07-14 at 3 40 13 PM" src="https://user-images.githubusercontent.com/11896652/125690007-e2fc640b-79a1-4922-8222-6b686aa38ec7.png">

Burnside is the area 47, which is missing the belonging data. It shows up as zero opacity on the map, while the other areas show the variation.
