### PR TITLE
Reintroduce covid_spread.sql into pipeline

### DIFF
--- a/pipeline/extract/covid_spread.sql
+++ b/pipeline/extract/covid_spread.sql
@@ -1,0 +1,10 @@
+select
+    week_number,
+    week_start,
+    week_end,
+    zip_code as zip,
+    population,
+    cases_weekly
+where
+    week_end <= "2021-05-08"
+limit 100000


### PR DESCRIPTION
Added back `covid_spread.sql` and reran the pipeline. The database is created completely, and all tests pass.

![image](https://user-images.githubusercontent.com/72165627/125828604-833ff6cd-5c44-441d-a52b-2394cea044c1.png)
