### PR TITLE
Add run shortcuts for make, pytest, and sqlite.

### DIFF
--- a/docs/pages/commands.md
+++ b/docs/pages/commands.md
@@ -17,6 +17,28 @@
 | `run sqlite` | Run the SQLite command line interface. |
 | `run update` | Update dependencies. |
 
+## Run With Additional Arguments
+
+You can use the `run` alias to run these commands with additional arguments. For example:
+
+```bash
+run make data/extracted/population.csv
+```
+
+...is equivalent to:
+
+```bash
+source .venv/bin/activate
+cd pipeline
+make data/extracted/population.csv
+```
+
+| Command | Description |
+|:--|:--|
+| `run make` | Run `make` with additional arguments. |
+| `run pytest` | Run `pytest` with additional arguments. |
+| `run sqlite3` | Run `sqlite3` with additional arguments. |
+
 ## Offline Pipeline
 
 - These commands should be run from the `transithealth/` directory.

--- a/docs/pages/makefiles.md
+++ b/docs/pages/makefiles.md
@@ -46,6 +46,14 @@ make reload
 
 ## Running Makefiles
 
+### Run Alias
+
+We have a special helper script called `run`. You can run any `make` command from the `transithealth/` folder like so:
+
+```bash
+run make (any additional arguments)
+```
+
 ### Specific Run
 
 You can run a `make` command like this:

--- a/docs/pages/new_dataset.md
+++ b/docs/pages/new_dataset.md
@@ -28,23 +28,13 @@ This guide walks you through how to add a new dataset to the offline pipeline.
 
 ### Terminal Tips
 
-When working on the offline pipeline, make sure you have your virtual environment activated:
+You can run any `make` command from the `transithealth/` directory by running:
 
 ```bash
-source .venv/bin/activate
+run make NAME_OF_TARGET
 ```
 
-All file paths in the offline pipeline are relative to the `pipeline/` directory. When working on the offline pipeline, it is recommended that you enter the `pipeline/` folder:
-
-```bash
-cd pipeline
-```
-
-You can run any `make` command from this folder by typing:
-
-```bash
-make NAME_OF_TARGET
-```
+This command enters the `pipeline/` directory before running, so you do not need to include `pipeline/` in the target name.
 
 It is also recommended that you check out the Makefiles guide to learn some helpful ways to run the offline pipeline:
 

--- a/run.sh
+++ b/run.sh
@@ -40,6 +40,17 @@ elif [ "$1" == "pipeline-all" ]; then
   cd pipeline
   make clean
   make
+  
+elif [ "$1" == "make" ]; then
+  echo "make ${@:2}"
+  source .venv/bin/activate
+  cd pipeline
+  make "${@:2}"
+
+elif [ "$1" == "pytest" ]; then
+  echo "pytest ${@:2}"
+  source .venv/bin/activate
+  pytest "${@:2}"
 
 elif [ "$1" == "tests" ]; then
   echo "Running tests..."

--- a/run.sh
+++ b/run.sh
@@ -47,6 +47,11 @@ elif [ "$1" == "make" ]; then
   cd pipeline
   make "${@:2}"
 
+elif [ "$1" == "sqlite3" ]; then
+  echo "sqlite3 ${@:2}"
+  source .venv/bin/activate
+  sqlite3 "${@:2}"
+
 elif [ "$1" == "pytest" ]; then
   echo "pytest ${@:2}"
   source .venv/bin/activate


### PR DESCRIPTION
Now you can run make commands from the comfort of the `transithealth/` directory!

Before you would have to do:

```bash
source .venv/bin/activate
cd pipeline
make data/extracted/income.csv
```

Now, you can run this command:

```bash
run make data/extracted/income.csv
```

The run command will take care of activating the virtual environment, entering the `pipeline/` directory, and running the `make` command with any arguments that you provide after `run make`. When the command finishes running, your terminal will still be in the `transithealth/` folder.

This means you should no longer have to manually activate the virtual environment or leave the `transithealth/` folder to run common commands!

You can also specify additional arguments for `run pytest` and `run sqlite3`, if needed.