### PR TITLE
Refactor timeline view to include metrics besides weekly

### DIFF
--- a/api/endpoints/timeline.py
+++ b/api/endpoints/timeline.py
@@ -5,25 +5,23 @@ from api.metrics.yearly import YearlyMetrics
 
 def make_blueprint(con):
     """
-    Creates blueprint for endpoints related to weekly metrics.
+    Creates blueprint for endpoints related to timeline metrics.
     """
 
-    app = Blueprint("weekly", __name__)
+    app = Blueprint("timeline", __name__)
     
-    metric = WeeklyMetrics(con)
+    weekly_metric = WeeklyMetrics(con)
     yearly_metric = YearlyMetrics(con)
 
     start_week_2018 = "2018-01-01"
     start_week_covid = "2020-03-02"
-    start_year_2018 = "2018"
 
     supported_metrics = {
-        "weekly_rideshare_pickups": lambda: metric.rideshare_pickups(since=start_week_2018),
-        "weekly_rideshare_pickups_covid": lambda: metric.rideshare_pickups(since=start_week_covid),
-        "weekly_rideshare_avg_cost": lambda: metric.rideshare_avg_cost_cents(since=start_week_2018),
-        "weekly_rideshare_avg_cost_covid": lambda: metric.rideshare_avg_cost_cents(since=start_week_covid),
-        "weekly_covid_cases": metric.covid_cases,
-        "yearly_disability_rate":lambda: metric.disability_rate(since=start_year_2018),
+        "weekly_rideshare_pickups": lambda: weekly_metric.rideshare_pickups(since=start_week_2018),
+        "weekly_rideshare_pickups_covid": lambda: weekly_metric.rideshare_pickups(since=start_week_covid),
+        "weekly_rideshare_avg_cost": lambda: weekly_metric.rideshare_avg_cost_cents(since=start_week_2018),
+        "weekly_rideshare_avg_cost_covid": lambda: weekly_metric.rideshare_avg_cost_cents(since=start_week_covid),
+        "weekly_covid_cases": weekly_metric.covid_cases,
         "yearly_belonging_rate_all": lambda: yearly_metric.belonging("all"),
         "yearly_belonging_rate_W": lambda: yearly_metric.belonging("W"),
         "yearly_belonging_rate_B": lambda: yearly_metric.belonging("B"),
@@ -32,10 +30,10 @@ def make_blueprint(con):
     }
 
 
-    @app.route("/weekly/metrics", methods=["POST"])
-    def weekly_metrics():
+    @app.route("/timeline/metrics", methods=["POST"])
+    def timeline_metrics():
         """
-        Returns the requested metrics by week.
+        Returns the requested metrics by date.
         """
         body = request.get_json()
         metric_list = body["metrics"] if "metrics" in body else []

--- a/api/endpoints/timeline.py
+++ b/api/endpoints/timeline.py
@@ -42,11 +42,11 @@ def make_blueprint(con):
             if metric_name in supported_metrics:
                 metric_fn = supported_metrics[metric_name]
                 for row in metric_fn():
-                    key = row["week"]
+                    key = row["date"]
                     if key not in res:
-                        res[key] = { "week": key }
+                        res[key] = { "date": key }
                     res[key][metric_name] = row["value"]
-        vals = list(sorted(res.values(), key=lambda r: r["week"]))
+        vals = list(sorted(res.values(), key=lambda r: r["date"]))
         return jsonify({ "metrics": vals })
 
     return app

--- a/api/metrics/weekly.py
+++ b/api/metrics/weekly.py
@@ -17,11 +17,11 @@ class WeeklyMetrics:
         """
         query = """
         SELECT
-            week,
+            week as date,
             SUM(n_trips) as value
         FROM rideshare
         WHERE week >= ?
-        GROUP BY week
+        GROUP BY date
         """
         cur = self.con.cursor()
         cur.execute(query, (since,))
@@ -36,14 +36,14 @@ class WeeklyMetrics:
         """
         query = """
         SELECT
-            week,
+            week as date,
             CAST(
                 SUM(n_trips * avg_cost_no_tip_cents)
                 / SUM(n_trips)
                 as INTEGER) as value
         FROM rideshare
         WHERE week >= ?
-        GROUP BY week
+        GROUP BY date
         """
         cur = self.con.cursor()
         cur.execute(query, (since,))
@@ -56,10 +56,10 @@ class WeeklyMetrics:
         """
         query = """
         SELECT
-            week,
+            week as date,
             SUM(cases_weekly) as value
         FROM covid_spread
-        GROUP BY week
+        GROUP BY date
         """
         cur = self.con.cursor()
         cur.execute(query)

--- a/api/metrics/weekly_test.py
+++ b/api/metrics/weekly_test.py
@@ -40,6 +40,6 @@ def test_rideshare_avg_price():
     metric = WeeklyMetrics(con)
 
     assert metric.rideshare_avg_cost_cents(since="2018-04-14") == [
-        { "week": "2018-04-14", "value": 1700 },
-        { "week": "2018-04-21", "value": 1500 }
+        { "date": "2018-04-14", "value": 1700 },
+        { "date": "2018-04-21", "value": 1500 }
     ], "Should compute average cost in cents since per week given date."

--- a/api/metrics/yearly.py
+++ b/api/metrics/yearly.py
@@ -15,13 +15,13 @@ class YearlyMetrics:
         """
         query = """
         SELECT
-            period_end_year || "-01-01" as week,
+            period_end_year || "-01-01" as date,
             value / 100 AS value,
             segment
         FROM belonging
         WHERE layer = "place"
         AND segment == "{segment}"
-        GROUP BY week
+        GROUP BY date
         """.format(segment=segment)
         cur = self.con.cursor()
         cur.execute(query)

--- a/api/metrics/yearly_test.py
+++ b/api/metrics/yearly_test.py
@@ -46,8 +46,8 @@ def test_annual_belonging_rate():
     metric = YearlyMetrics(con)
 
     assert metric.belonging(segment="all") == [
-        { "week": "2015-01-01", "value": 55.6 / 100, "segment": "all" },
-        { "week": "2016-01-01", "value": 45.2 / 100, "segment": "all" },
-        { "week": "2017-01-01", "value": 37.1 / 100, "segment": "all" },
-        { "week": "2018-01-01", "value": 35.4 / 100, "segment": "all" }
+        { "date": "2015-01-01", "value": 55.6 / 100, "segment": "all" },
+        { "date": "2016-01-01", "value": 45.2 / 100, "segment": "all" },
+        { "date": "2017-01-01", "value": 37.1 / 100, "segment": "all" },
+        { "date": "2018-01-01", "value": 35.4 / 100, "segment": "all" }
     ], "Should give the belonging rate per year with just the given segment."

--- a/api/server.py
+++ b/api/server.py
@@ -9,7 +9,7 @@ from decouple import config
 from flask import (
     Flask,
     jsonify,
-    request
+    request,
 )
 from flask_cors import CORS
 import sqlite3
@@ -20,7 +20,7 @@ from api.endpoints import (
     fake,
     question,
     rideshare,
-    weekly
+    timeline,
 )
 
 
@@ -38,7 +38,7 @@ app.register_blueprint(community.make_blueprint(con))
 app.register_blueprint(fake.make_blueprint(con))
 app.register_blueprint(question.make_blueprint(con))
 app.register_blueprint(rideshare.make_blueprint(con))
-app.register_blueprint(weekly.make_blueprint(con))
+app.register_blueprint(timeline.make_blueprint(con))
 
 # Start the server on the default host.
 if __name__ == "__main__":

--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -35,7 +35,7 @@ const weekFormat = new Intl.DateTimeFormat("en-US", {
 
 async function getTimelineMetrics(metrics) {
   const req = await fetch(
-    `${process.env.NEXT_PUBLIC_API}/weekly/metrics`,
+    `${process.env.NEXT_PUBLIC_API}/timeline/metrics`,
     {
       method: "POST",
       headers: {

--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -27,7 +27,7 @@ const defaultColors = [
   "#a453f5",
   "#f5cd53",
 ];
-const weekFormat = new Intl.DateTimeFormat("en-US", {
+const dateFormat = new Intl.DateTimeFormat("en-US", {
   month: "long",
   day: "numeric",
   year: "numeric",
@@ -55,10 +55,10 @@ function CustomToolTip({ active, payload, label, metrics, selectedPayload }) {
     return null;
   }
   const d = payload[0].payload;
-  const date = new Date(d.week);
+  const date = new Date(d.date);
   return (
     <div className="CustomToolTip">
-      <h4>{weekFormat.format(new Date(d.week))}</h4>
+      <h4>{dateFormat.format(new Date(d.date))}</h4>
       {metrics.filter(({ id: m}) => d[m]).map(({ id: m }, i) => (
         <p key={i}>
           <span>{supportedMetrics[m].name}: </span>
@@ -78,7 +78,7 @@ function TimelineChart({ data, metrics }) {
         margin={{ left: 30, right: 30, bottom: 30, top: 10 }}
       >
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="week" domain={["dataMin", "dataMax"]}>
+        <XAxis dataKey="date" domain={["dataMin", "dataMax"]}>
           <Label
             value="Date"
             position="bottom"

--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { MetricSelector } from '../components/Common'
 import {
-  weeklyMetrics,
+  timelineMetrics,
   timelineExplorerDefaults
 } from '../site/metrics'
 import {
@@ -19,7 +19,7 @@ import {
   Area,
 } from 'recharts'
 
-const supportedMetrics = weeklyMetrics;
+const supportedMetrics = timelineMetrics;
 const defaultMetricToAdd = timelineExplorerDefaults.metricToAdd;
 const defaultColors = [
   "#099178",
@@ -80,7 +80,7 @@ function TimelineChart({ data, metrics }) {
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="week" domain={["dataMin", "dataMax"]}>
           <Label
-            value="Week"
+            value="Date"
             position="bottom"
             offset={10}
           />
@@ -203,8 +203,7 @@ export default function TimelineExplorer(props) {
   return (
     <div>
       <div className="center">
-        <h2>By Week</h2>
-        <p>{ isLoading ? "Loading..." : "" }</p>
+        <span>{ isLoading ? "Loading..." : "" }</span>
       </div>
       <TimelineChart data={data} metrics={metrics} />
       <h3>Select Metrics</h3>

--- a/app/pages/explorer.js
+++ b/app/pages/explorer.js
@@ -23,7 +23,7 @@ export default function Explorer() {
           <div className="columns">
             <div className="column center">
               <h2>Timeline View</h2>
-              <p>View data over time, on a weekly basis.</p>
+              <p>View data over time.</p>
               <br />
               <Link href="/timeline">
                 <a className="btn primary">Timeline View</a>

--- a/app/pages/timeline.js
+++ b/app/pages/timeline.js
@@ -18,7 +18,6 @@ export default function TimelineView() {
         <div className="page">
           <div className="center">
             <h1>Timeline View</h1>
-            <p>View data over time, on a weekly basis.</p>
           </div>
           <br />
           <TimelineExplorer metrics={timelineExplorerDefaults.defaultMetrics} />

--- a/app/site/metrics.js
+++ b/app/site/metrics.js
@@ -109,7 +109,7 @@ export const communityMetrics = {
   },
 };
 
-export const weeklyMetrics = {
+export const timelineMetrics = {
   weekly_rideshare_pickups: {
     name: "Weekly Rideshare Pickups",
     units: "trips",

--- a/docs/pages/new_endpoint.md
+++ b/docs/pages/new_endpoint.md
@@ -373,7 +373,7 @@ The file `app/site/metrics.js` configures the metrics for the TransitHealth Data
 You will mostly likely add your new metric to one of these two configs:
 
 - `communityMetrics` specifies metrics for the Community View
-- `weeklyMetrics` specifies metrics for the Timeline View
+- `timelineMetrics` specifies metrics for the Timeline View
 
 Add your metric like this:
 

--- a/docs/pages/tasks.md
+++ b/docs/pages/tasks.md
@@ -105,7 +105,7 @@ For more information, read the API section in the guide on how to [add a new end
 
 ### Examples
 
-- Endpoint to get data for timeline view: [`weekly_metrics()` in `api/endpoints/weekly.py`](../../api/endpoints/weekly.py)
+- Endpoint to get data for timeline view: [`timeline_metrics()` in `api/endpoints/timeline.py`](../../api/endpoints/timeline.py)
 - Endpoint to get data about pooled rideshare trips: [`pooled_trips()` in `api/endpoints/question.py`](../../api/endpoints/question.py)
 
 ### Checklist


### PR DESCRIPTION
Fixes #62 

- Revised website copy on frontend to be clear that timeline view supports date-based metrics, not just weekly
- Renamed internal fields to be clear that timeline view supports any metric with a `date` key
- Updated tests, manually tested timeline view and metrics

If you are working on a metric for the timeline view, make sure you pull the latest version from `main` with this PR, that way you don't develop on the old versions and get merge conflicts.