### PR TITLE
New options for run app: hotswap API and serve static site.

### DIFF
--- a/api/dev.sh
+++ b/api/dev.sh
@@ -7,7 +7,7 @@ source .venv/bin/activate
 pip3 install -r requirements.txt
 
 # Refresh IP address for Cloud9 instance
-if [ -n "$1" ]; then
+if [ "$1" == "9" ]; then
     ./api/scripts/refresh.sh
     INSTANCE_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
     echo "Launching API To: http://$INSTANCE_IP:5000"

--- a/app/dev.sh
+++ b/app/dev.sh
@@ -11,9 +11,14 @@ if [ "$1" == "9" ]; then
 fi
 
 # Use the production API instead of your local API
-if [ "$2" == "prod-api" ]; then
+if [ "$2" == "api" ]; then
     echo "Connecting to prod API instead of local. It may take some time to wake up..."
-    BACKEND_URL="http://transithealth.herokuapp.com"
+    if [ "$3" == "prod" ]; then
+        BACKEND_URL="http://transithealth.herokuapp.com"
+    else
+        BACKEND_URL="$3"
+    fi
+    echo "Connecting to Backend: $BACKEND_URL"
     echo $(curl "$BACKEND_URL")
     sed -i "s,NEXT_PUBLIC_API=.*,NEXT_PUBLIC_API=$BACKEND_URL," app/.env.local
 fi

--- a/app/dev.sh
+++ b/app/dev.sh
@@ -21,5 +21,14 @@ fi
 # Enter app directory
 cd app
 
-# Start Next.js development server
-yarn dev
+# Check whether to run static or dynamic site
+if [ "$2" == "static" ]; then
+    # Build, export, and serve static site
+    echo "Building static site instead of dynamic site. This will not listen for changes."
+    yarn build
+    yarn export
+    python3 -m http.server 8001
+else
+    # Start Next.js development server
+    yarn dev
+fi

--- a/app/dev.sh
+++ b/app/dev.sh
@@ -4,10 +4,18 @@
 yarn install
 
 # Refresh IP address for Cloud9 instance
-if [ -n "$1" ]; then
+if [ "$1" == "9" ]; then
     ./api/scripts/refresh.sh
     INSTANCE_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
     echo "Launching Frontend To: http://$INSTANCE_IP:8001/transithealth"
+fi
+
+# Use the production API instead of your local API
+if [ "$2" == "prod-api" ]; then
+    echo "Connecting to prod API instead of local. It may take some time to wake up..."
+    BACKEND_URL="http://transithealth.herokuapp.com"
+    echo $(curl "$BACKEND_URL")
+    sed -i "s,NEXT_PUBLIC_API=.*,NEXT_PUBLIC_API=$BACKEND_URL," app/.env.local
 fi
 
 # Enter app directory

--- a/docs/pages/commands.md
+++ b/docs/pages/commands.md
@@ -11,7 +11,7 @@
 |:--|:--|
 | `run api 9` | Start the backend API on Cloud9. |
 | `run app 9` | Start the frontend app on Cloud9. |
-| `run app 9 prod-api` | Start the frontend using prod API. Good for frontend-only work. |
+| `run app 9 api prod` | Start the frontend using prod API. Good for frontend-only work. |
 | `run app 9 static` | Serve the static version of the frontend. Good for backend-only work. |
 | `run db` | Get the latest database from the compressed files. |
 | `run tests` | Run all tests. |

--- a/docs/pages/commands.md
+++ b/docs/pages/commands.md
@@ -11,7 +11,8 @@
 |:--|:--|
 | `run api 9` | Start the backend API on Cloud9. |
 | `run app 9` | Start the frontend app on Cloud9. |
-| `run app 9 prod-api` | Start the frontend app on Cloud9, using prod API. |
+| `run app 9 prod-api` | Start the frontend using prod API. Good for frontend-only work. |
+| `run app 9 static` | Serve the static version of the frontend. Good for backend-only work. |
 | `run db` | Get the latest database from the compressed files. |
 | `run tests` | Run all tests. |
 | `run notebooks 9` | Run the Jupyter notebook server. |

--- a/docs/pages/commands.md
+++ b/docs/pages/commands.md
@@ -11,6 +11,7 @@
 |:--|:--|
 | `run api 9` | Start the backend API on Cloud9. |
 | `run app 9` | Start the frontend app on Cloud9. |
+| `run app 9 prod-api` | Start the frontend app on Cloud9, using prod API. |
 | `run db` | Get the latest database from the compressed files. |
 | `run tests` | Run all tests. |
 | `run notebooks 9` | Run the Jupyter notebook server. |

--- a/notebooks/start.sh
+++ b/notebooks/start.sh
@@ -7,7 +7,7 @@ source .venv/bin/activate
 pip3 install -r requirements.txt
 
 # Refresh IP address for Cloud9 instance
-if [ -n "$1" ]; then
+if [ "$1" == "9" ]; then
     ./api/scripts/refresh.sh
     INSTANCE_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
     echo "Running Jupyter notebook server on: http://$INSTANCE_IP:8080"

--- a/run.sh
+++ b/run.sh
@@ -10,8 +10,8 @@ if [ "$1" == "api" ]; then
   
 elif [ "$1" == "app" ]; then
   echo "Starting frontend app..."
-  echo "./app/dev.sh $2"
-  ./app/dev.sh "$2"
+  echo "./app/dev.sh ${@:2}"
+  ./app/dev.sh "${@:2}"
   
 elif [ "$1" == "db" ]; then
   echo "Making uncompressed database..."

--- a/run.sh
+++ b/run.sh
@@ -61,6 +61,9 @@ elif [ "$1" == "tests" ]; then
   echo "Running tests..."
   source .venv/bin/activate
   pytest -vvl
+  
+elif [ "$1" == "test" ]; then
+  echo "Did you mean 'run tests' ?"
 
 elif [ "$1" == "update" ]; then
   echo "Updating dependencies..."
@@ -74,6 +77,9 @@ elif [ "$1" == "notebooks" ]; then
   echo "Starting Jupyter notebook server..."
   echo "./notebooks/start.sh $2"
   ./notebooks/start.sh "$2"
+  
+elif [ "$1" == "notebook" ]; then
+  echo "Did you mean 'run notebooks' ?"
 
 elif [ "$1" == "sqlite" ]; then
   echo "Starting SQLite command line interface..."


### PR DESCRIPTION
New options for running the app, added to the common commands doc.

- **If you are doing frontend work only,** you can use `run app 9 api prod` to run your app in development mode, while using the production API. This means you do not have to run the API on your Cloud9.
- **If you are doing backend work only,** you can use `run app 9 static` to serve a static version of the app, while using your Cloud9 API. This means the frontend will not rebuild on changes, but will be faster to navigate between pages.

Here is a screencast showing a demo: https://www.loom.com/share/7751ee3dd41142e2a4c25159b88d1dce