### PR TITLE
Improve Frontend Belonging Formatting

### DIFF
--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -21,6 +21,16 @@ const EMPTY_AREA = {
   belongingRateFormatted: "?",
 };
 
+const RADIAN = Math.PI / 180;
+const renderCustomizedLabel = ({ percent, index }) => {
+
+  return (
+    <text>
+      {`${(percent * 100).toFixed(1)}%`}
+    </text>
+  );
+};
+
 function transformData(response, error, selectedArea) {
   if (!response || error) {
     return {
@@ -40,14 +50,17 @@ function transformData(response, error, selectedArea) {
     {
       label: "Feels Belonging",
       value: areaData.belonging_rate_2018,
+      valueFormatted: Formatter.percentWithOneDecimal(areaData.belonging_rate_2018),
       color: Color.Indigo
     },
     {
       label: "Does Not Feel Belonging",
       value: 1 - areaData.belonging_rate_2018,
+      valueFormatted: Formatter.percentWithOneDecimal(1 - areaData.belonging_rate_2018),
       color: Color.Salmon
     }
     ]
+
   
   return {
     chartData: data,
@@ -57,6 +70,38 @@ function transformData(response, error, selectedArea) {
 
 function ExamplePieChart(props) {
   const { data } = props
+  
+  const CustomTooltip = ({ active, payload, label }) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="custom-tooltip">
+        <p className="label">{`${payload[0].name} : ${(payload[0].value * 100).toFixed(1)}%`}</p>
+      </div>
+    );
+  }
+
+  return null;
+};
+  
+  const RADIAN = Math.PI / 180;
+  const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, color, valueFormatted, index }) => {
+    const radius = 25 + innerRadius + (outerRadius - innerRadius);
+    // eslint-disable-next-line
+    const x = cx + radius * Math.cos(-midAngle * RADIAN);
+    // eslint-disable-next-line
+    const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+    return (
+      <text x={x}
+            y={y}
+            fill={color}
+            textAnchor={x > cx ? "start" : "end"}
+            dominantBaseline="central">
+        {`${valueFormatted}`}
+      </text>
+    );
+  };
+  
   return (
     <ResponsiveContainer width="100%" height={400}>
       <PieChart
@@ -68,7 +113,7 @@ function ExamplePieChart(props) {
           data={data}
           nameKey="label"
           dataKey="value"
-          label
+          label={renderCustomizedLabel}
           cx="50%"
           cy="50%"
           fill=""
@@ -81,7 +126,7 @@ function ExamplePieChart(props) {
             />
           ))}
         </Pie>
-        <Tooltip />
+        <Tooltip content={<CustomTooltip />} wrapperStyle={{ backgroundColor: "white", borderColor: "LightGrey", borderStyle: "solid", borderWidth: "thin" }}/>
         <Legend
           layout="horizontal"
           verticalAlign="top"

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -86,9 +86,7 @@ function ExamplePieChart(props) {
   const RADIAN = Math.PI / 180;
   const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, color, valueFormatted, index }) => {
     const radius = 25 + innerRadius + (outerRadius - innerRadius);
-    // eslint-disable-next-line
     const x = cx + radius * Math.cos(-midAngle * RADIAN);
-    // eslint-disable-next-line
     const y = cy + radius * Math.sin(-midAngle * RADIAN);
 
     return (

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -21,15 +21,6 @@ const EMPTY_AREA = {
   belongingRateFormatted: "?",
 };
 
-const RADIAN = Math.PI / 180;
-const renderCustomizedLabel = ({ percent, index }) => {
-
-  return (
-    <text>
-      {`${(percent * 100).toFixed(1)}%`}
-    </text>
-  );
-};
 
 function transformData(response, error, selectedArea) {
   if (!response || error) {

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -75,7 +75,7 @@ function ExamplePieChart(props) {
     // Changes the tooltip to display the formatted percentage rather than a decimal
     return (
       <div className="custom-tooltip" style={tooltipStyle}>
-        <p className="label">{`${payload[0].name} : ${(payload[0].value * 100).toFixed(1)}%`}</p>
+        <p className="label">{`${payload[0].name} : ${payload[0].payload.valueFormatted}`}</p>
       </div>
     );
   }
@@ -143,7 +143,6 @@ export default function BelongingRates(props) {
     method: "POST",
     body: JSON.stringify({metrics: ["belonging_rate_2018"]})
   }, []);
-  console.log(data)
   const selectedArea = 34
   const { chartData, areaData } = transformData(data, error, selectedArea);
   

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -21,7 +21,6 @@ const EMPTY_AREA = {
   belongingRateFormatted: "?",
 };
 
-
 function transformData(response, error, selectedArea) {
   if (!response || error) {
     return {
@@ -62,10 +61,18 @@ function transformData(response, error, selectedArea) {
 function ExamplePieChart(props) {
   const { data } = props
   
+  const tooltipStyle = {
+    backgroundColor: "white", 
+    borderColor: "LightGrey", 
+    borderStyle: "solid", 
+    borderWidth: "thin"
+  };
+  
   const CustomTooltip = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
+    // Changes the tooltip to display the formatted percentage rather than a decimal
     return (
-      <div className="custom-tooltip">
+      <div className="custom-tooltip" style={tooltipStyle}>
         <p className="label">{`${payload[0].name} : ${(payload[0].value * 100).toFixed(1)}%`}</p>
       </div>
     );
@@ -76,10 +83,11 @@ function ExamplePieChart(props) {
   
   const RADIAN = Math.PI / 180;
   const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, color, valueFormatted, index }) => {
+    // Takes various characteristics of the pie chart, as well as color, valueFormatted and index, to calculate the position of the label
     const radius = 25 + innerRadius + (outerRadius - innerRadius);
     const x = cx + radius * Math.cos(-midAngle * RADIAN);
     const y = cy + radius * Math.sin(-midAngle * RADIAN);
-
+    // Returns the text label itself using computed x and y position, as well as provided color and formatted percentage.
     return (
       <text x={x}
             y={y}
@@ -115,7 +123,7 @@ function ExamplePieChart(props) {
             />
           ))}
         </Pie>
-        <Tooltip content={<CustomTooltip />} wrapperStyle={{ backgroundColor: "white", borderColor: "LightGrey", borderStyle: "solid", borderWidth: "thin" }}/>
+        <Tooltip content={<CustomTooltip />} />
         <Legend
           layout="horizontal"
           verticalAlign="top"

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -85,11 +85,11 @@ function ExamplePieChart(props) {
   
   const RADIAN = Math.PI / 180;
   const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, color, valueFormatted, index }) => {
-    // Takes various characteristics of the pie chart, as well as color, valueFormatted and index, to calculate the position of the label
+    // Takes various characteristics of the pie chart to calculate the position of the label
     const radius = 25 + innerRadius + (outerRadius - innerRadius);
     const x = cx + radius * Math.cos(-midAngle * RADIAN);
     const y = cy + radius * Math.sin(-midAngle * RADIAN);
-    // Returns the text label itself using computed x and y position, as well as provided color and formatted percentage.
+    // Returns the text label using computed x and y position, as well as provided color and formatted percentage.
     return (
       <text x={x}
             y={y}

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -61,12 +61,14 @@ function transformData(response, error, selectedArea) {
 function ExamplePieChart(props) {
   const { data } = props
   
+  
   const tooltipStyle = {
     backgroundColor: "white", 
     borderColor: "LightGrey", 
     borderStyle: "solid", 
     borderWidth: "thin"
   };
+  
   
   const CustomTooltip = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
@@ -77,9 +79,9 @@ function ExamplePieChart(props) {
       </div>
     );
   }
-
   return null;
-};
+  };
+  
   
   const RADIAN = Math.PI / 180;
   const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, color, valueFormatted, index }) => {
@@ -98,6 +100,7 @@ function ExamplePieChart(props) {
       </text>
     );
   };
+  
   
   return (
     <ResponsiveContainer width="100%" height={400}>


### PR DESCRIPTION
This was first attempted in I believe both PR #79 and #77 but couldn't be figured out, so I thought it'd be good to find out a solution to the unformatted values being used by the page.

I managed to use Recharts and React API and examples to create custom styling for both piechart label and tooltip, including the change from the unformatted decimal to formatted percentage. I tried doing this while keeping the footprint of the actual piechart code to a minimum, meaning I had to use various `const`s to define the behavior I wanted, which could then be easily plugged into the syntax for the piechart.

The code is a bit inconsistent with itself, the manner in which Recharts interacts with the provided data is a bit confusing. For the custom tooltip here, I couldn't figure out a way to use the previously added `valueFormatted`, so I instead performed the same operation that our Formatter does with `percentWithOneDecimal`. Perhaps there is a better way of handling this that I'm not aware of.

https://github.com/scarletstudio/transithealth/blob/8d8d221e7763927fe8b59f3c1f5059e7c3d2ed04/app/components/questions/BelongingRates.js#L73-L79

On the other hand, the code for the custom label is a bit easier to work with. It's able to calculate the position of the labels themselves using a few math operations and otherwise consists of using the existing `color` and `valueFormatted` that was set in the data to return a simple piece of text, which should make it useful if we ever manage to add a menu of some sort to change the area being displayed on the page.

Unfortunately, I'm not sure how well this would work with other data visualization types. However, what I've read from documentation and sources online indicates it should be similarly possible.