### PR TITLE
Fix bug where changing metric causes scatter view tooltip to display NaN or crash the app

### DIFF
--- a/app/components/CommunityScatterExplorer.js
+++ b/app/components/CommunityScatterExplorer.js
@@ -59,11 +59,17 @@ function getGeoMapMetric(metrics, selectedMetric, minAlpha=0.05) {
   return metricMapData;
 }
 
-function CustomToolTip({ active, payload, label, metrics, selectedPayload }) {
-  if (!active || !payload || payload.length === 0) {
+function CustomToolTip({ active, payload, label, metrics }) {
+  // The ?. is called "optional chaining"
+  // If the property after the ?. is not found, we will return undefined
+  // and stop trying to evaluate the remaining nested properties.
+  const d = payload?.[0]?.payload || {};
+  // Check if any of the metrics are not in the data, which happens if the
+  // tooltip is open while switching metrics because the value of d is stale
+  const metricNotInData = metrics.filter(m => !(m in d)).length > 0;
+  if (!active || !d || metricNotInData) {
     return null;
   }
-  const d = payload[0].payload;
   return (
     <div className="CustomToolTip">
       <h4>{d.name}</h4>


### PR DESCRIPTION
Fixes bug #92 

This screencast explains the cause of the bug (stale data in the custom tooltip) and the solution (detect when the data doesn't have the new metrics and tell the tooltip not to display).

https://www.loom.com/share/88c9b582ac8447cb94ed529cc3c206cd

Thanks @fabrego524 and @wpj0110 for helping find this bug!

Clarifying question from the video:

> In the video, you said that the data inside the custom tooltip is stale. Then why do the metrics in the tooltip change but not the payload?

> Yes, that is something I should have explained in the video. The metrics change because the metrics are passed into the custom tooltip as a property from the parent component. However, the payload is managed by the Recharts library that we use for data visualizations and is not under the control of either component. Recharts does not update the payload while the tooltip is open, so we get stale data. I couldn't find out online whether this is the intended behavior of Recharts or if this is bug.