### PR TITLE
Hack to fix dates on timeline tooltip.

### DIFF
--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -51,14 +51,18 @@ async function getTimelineMetrics(metrics) {
 }
 
 function CustomToolTip({ active, payload, label, metrics, selectedPayload }) {
-  if (!active || !payload || payload.length === 0) {
+  const d = payload?.[0]?.payload;
+  if (!active || !d) {
     return null;
   }
-  const d = payload[0].payload;
-  const date = new Date(d.date);
+  // This is very hacky. If there is a space after the date, it will be parsed
+  // without the local timezone offset, that way the date returned by the API
+  // will be displayed as intended, no matter what timezone the client is in.
+  // StackOverflow: https://stackoverflow.com/q/47359812
+  const localDate = new Date(`${d.date} ?`);
   return (
     <div className="CustomToolTip">
-      <h4>{dateFormat.format(new Date(d.date))}</h4>
+      <h4>{dateFormat.format(localDate)}</h4>
       {metrics.filter(({ id: m}) => d[m]).map(({ id: m }, i) => (
         <p key={i}>
           <span>{supportedMetrics[m].name}: </span>


### PR DESCRIPTION
Fixes bug #61 

# Try the Fix

To try this change out in your Cloud9:

```bash
cd transithealth
git fetch
git checkout fix-timeline-dates
run app 9 api prod
```

- Go to the timeline view
- Remove the default metrics
- Add one of the belonging metrics
- Hover over one of the data points and check if the date is correct

# Before (Bug)

![Screen Shot 2021-07-22 at 12 26 19 AM](https://user-images.githubusercontent.com/11896652/126593615-d1906d51-7623-48c1-9540-e4766507636b.png)

# After (Fixed)

![Screen Shot 2021-07-22 at 12 25 49 AM](https://user-images.githubusercontent.com/11896652/126593617-a96e7ec6-048a-4e98-b993-0748404e2e76.png)