### PR TITLE
Added 2 more years for Median Income metric

### DIFF
--- a/api/endpoints/community.py
+++ b/api/endpoints/community.py
@@ -23,6 +23,8 @@ def make_blueprint(con):
         "total_population_2010": lambda: metric.population(year=2010, segment="all"),
         "total_population_2019": lambda: metric.population(year=2019, segment="all"),
         "median_income_2010": lambda: metric.income(year=2010, segment="all"),
+        "median_income_2017": lambda: metric.income(year=2017, segment="all"),
+        "median_income_2018": lambda: metric.income(year=2018, segment="all"),
         "median_income_2019": lambda: metric.income(year=2019, segment="all"),
         "total_covid_cases": lambda: metric.covid_spread_sum_by_area("cases_weekly"),
         "disability_rate_2018":lambda: metric.disability_rate(year=2018, segment="all"),

--- a/app/site/metrics.js
+++ b/app/site/metrics.js
@@ -71,6 +71,18 @@ export const communityMetrics = {
     format: Formatter.dollarsUSD,
     fullFormat: Formatter.dollarsUSD,
   },
+  median_income_2017: {
+    name: "2017 Median Income",
+    units: "dollars",
+    format: Formatter.dollarsUSD,
+    fullFormat: Formatter.dollarsUSD,
+  },
+  median_income_2018: {
+    name: "2018 Median Income",
+    units: "dollars",
+    format: Formatter.dollarsUSD,
+    fullFormat: Formatter.dollarsUSD,
+  },
   median_income_2019: {
     name: "2019 Median Income",
     units: "dollars",


### PR DESCRIPTION
Went ahead and implemented 2 additional years for the Median Income metric, 2017 and 2018. This will expand the data a bit for the scatter plot and provide a bit more data for some questions in the future.