### PR TITLE
Frontend Belonging Solution for Burnside

### DIFF
--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -59,8 +59,9 @@ function transformData(response, error, selectedArea) {
 
 function ExamplePieChart(props) {
   const { data } = props
+  const { areaData } = props
   
-  if(!data[0].value){
+  if(!data?.[0]?.value){
     return null;
   }
   

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -59,7 +59,6 @@ function transformData(response, error, selectedArea) {
 
 function ExamplePieChart(props) {
   const { data } = props
-  const { areaData } = props
   
   if(!data?.[0]?.value){
     return null;

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -49,14 +49,14 @@ function transformData(response, error, selectedArea) {
       valueFormatted: Formatter.percentWithOneDecimal(1 - areaData.belonging_rate_2018),
       color: Color.Salmon
     }
-    ]
-    
+  ]
+
   const dataFlag = (() => {
   if (areaData.belongingRateFormatted==="NaN%")
     return 1
   else
     return 0
-})();
+  })();
   
   return {
     chartData: data,
@@ -175,7 +175,7 @@ function GenerateMessage(props) {
       <p>Waiting for data...</p>  
     )
   }
-  
+
   if(props.dataFlag){
     return (
       <span>There is no data for {props.areaData.name}</span>

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -50,17 +50,27 @@ function transformData(response, error, selectedArea) {
       color: Color.Salmon
     }
     ]
-
+    
+  const dataFlag = (() => {
+  if (areaData.belongingRateFormatted==="NaN%")
+    return 1
+  else
+    return 0
+})();
   
   return {
     chartData: data,
     areaData,
+    dataFlag,
   }
 }
 
 function ExamplePieChart(props) {
   const { data } = props
   
+  if(props.dataFlag){
+    return null;
+  }
   
   const tooltipStyle = {
     backgroundColor: "white", 
@@ -156,7 +166,25 @@ function AreaSelector(props) {
         ))}
       </select>
     </div>
-  )
+  );
+}
+
+function GenerateMessage(props) {
+  if(!props.areaData){
+    return (
+      <p>Waiting for data...</p>  
+    )
+  }
+  
+  if(props.dataFlag){
+    return (
+      <span>There is no data for {props.areaData.name}</span>
+    )
+  } else {
+    return (
+      <span>Based on the data from 2018, {props.areaData.belongingRateFormatted} of people in {props.areaData.name} agree or strongly agree that they feel a sense of belonging in their community</span>
+    )
+  }
 }
 
 export default function BelongingRates(props) {
@@ -165,7 +193,7 @@ export default function BelongingRates(props) {
     body: JSON.stringify({metrics: ["belonging_rate_2018"]})
   }, []);
   const [selectedArea, setSelectedArea] = useState(1)
-  const { chartData, areaData } = transformData(data, error, selectedArea);
+  const { chartData, areaData, dataFlag } = transformData(data, error, selectedArea);
   
   useEffect(() => {
     props.setContentIsLoading(loading);
@@ -180,12 +208,12 @@ export default function BelongingRates(props) {
         <FailureNotification error={error} data={data} />
       </div>
       <div className="center">
-        <ExamplePieChart data={chartData} />
+        <ExamplePieChart data={chartData} dataFlag={dataFlag} />
         <br />
       </div>
       <div className="center medium-width">
         <p>
-        <span>Based on data from 2018, {areaData.belongingRateFormatted} of people in {areaData.name} agree or strongly agree that they feel a sense of belonging in their community.</span>
+        <GenerateMessage areaData={areaData} dataFlag={dataFlag} />
         </p>
       </div>
     </div>

--- a/app/components/questions/BelongingRates.js
+++ b/app/components/questions/BelongingRates.js
@@ -50,25 +50,17 @@ function transformData(response, error, selectedArea) {
       color: Color.Salmon
     }
   ]
-
-  const dataFlag = (() => {
-  if (areaData.belongingRateFormatted==="NaN%")
-    return 1
-  else
-    return 0
-  })();
   
   return {
     chartData: data,
     areaData,
-    dataFlag,
   }
 }
 
 function ExamplePieChart(props) {
   const { data } = props
   
-  if(props.dataFlag){
+  if(!data[0].value){
     return null;
   }
   
@@ -169,20 +161,22 @@ function AreaSelector(props) {
   );
 }
 
-function GenerateMessage(props) {
-  if(!props.areaData){
+function AreaBelongingMessage(props) {
+  const { areaData } = props; 
+  
+  if(!areaData){
     return (
       <p>Waiting for data...</p>  
     )
   }
-
-  if(props.dataFlag){
+  
+  if(!areaData.belonging_rate_2018){
     return (
-      <span>There is no data for {props.areaData.name}</span>
+      <span>There is no data for {areaData.name}</span>
     )
   } else {
     return (
-      <span>Based on the data from 2018, {props.areaData.belongingRateFormatted} of people in {props.areaData.name} agree or strongly agree that they feel a sense of belonging in their community</span>
+      <span>Based on the data from 2018, {areaData.belongingRateFormatted} of people in {areaData.name} agree or strongly agree that they feel a sense of belonging in their community</span>
     )
   }
 }
@@ -193,7 +187,7 @@ export default function BelongingRates(props) {
     body: JSON.stringify({metrics: ["belonging_rate_2018"]})
   }, []);
   const [selectedArea, setSelectedArea] = useState(1)
-  const { chartData, areaData, dataFlag } = transformData(data, error, selectedArea);
+  const { chartData, areaData } = transformData(data, error, selectedArea);
   
   useEffect(() => {
     props.setContentIsLoading(loading);
@@ -208,12 +202,12 @@ export default function BelongingRates(props) {
         <FailureNotification error={error} data={data} />
       </div>
       <div className="center">
-        <ExamplePieChart data={chartData} dataFlag={dataFlag} />
+        <ExamplePieChart data={chartData} />
         <br />
       </div>
       <div className="center medium-width">
         <p>
-        <GenerateMessage areaData={areaData} dataFlag={dataFlag} />
+        <AreaBelongingMessage areaData={areaData} />
         </p>
       </div>
     </div>

--- a/app/site/questions.js
+++ b/app/site/questions.js
@@ -34,7 +34,7 @@ export const questionsParams = {
     description: "Burnside is the neighborhood with the highest disability rate. What percentage of residents in Burnside, Chicago have an included disability?",
   },
   "belonging-example": {
-    title: "Belonging Rates",
+    title: "Belonging Rates of Chicago",
     author: "Fabian Abrego",
     component: "belonging-rates",
     description: "Over the years, the residents of an area may feel differently about their sense of belonging. What is this rate for a given neighborhood?",


### PR DESCRIPTION
Implemented a simple check to determine if a particular community area returns `NaN` for its value which is passed to both the pie chart and a new `function generateMessage` which will change the text on the page in case the community area has no present data.

One thing of note is that this particular section of code feels a bit clunky for what it does. This specifically looks at the belonging rate of the area whose data is being transformed, and sees if it is `NaN`. There may be some way to check the value directly, however, I was only able to figure out how to check the formatted string instead.

https://github.com/scarletstudio/transithealth/blob/2a039b783069850ce59a8cf615e1025dfeb1747e/app/components/questions/BelongingRates.js#L53-L60

The new function ensures that the parent component isn't responsible for generating this message. It allows for other types of checks such as data from different periods or from different populations. I'm not confident that it's the best practice, but I'm sure it will be useful.

https://github.com/scarletstudio/transithealth/blob/2a039b783069850ce59a8cf615e1025dfeb1747e/app/components/questions/BelongingRates.js#L171-L189

A similar check is added to the piechart from Recharts to hide the element when there is no data for an area. This was the simplest method used in the React documentation, but it's not exactly the cleanest in terms of appearance.

https://github.com/scarletstudio/transithealth/blob/2a039b783069850ce59a8cf615e1025dfeb1747e/app/components/questions/BelongingRates.js#L70-L74

Lastly, I made a simple change to the name of this sample Question to be more clear about its contents.
