### PR TITLE
Improve timeline view x-axis.

### DIFF
--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -108,6 +108,9 @@ function TimelineChart({ data, metrics }) {
     
   const ticks = chartData
     .map(d => new Date(d.timestamp))
+    // Only show tick if it is the first of a new year
+    // Note: Recharts will also hide ticks on its own
+    // to preserve space between tick labels
     .filter((dt, i, arr) => {
       const prev = arr?.[i - 1];
       return prev?.getYear() !== dt.getYear();

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -325,6 +325,14 @@ a.btn {
     margin-right: 0.5em;
 }
 
+@media screen and (max-width: 500px) {
+    
+    .TimelineMetrics .MetricSelector select {
+        width: 100%;
+    }
+
+}
+
 .TimelineMetrics .MetricSelector {
     display: inline-block;
     vertical-align: middle;


### PR DESCRIPTION
Fixes #60 

- Changes XAxis from date type to number type, which is better supported by Recharts and allows dataMin and dataMax to work automatically, which dynamically resizes the x-axis domain based on the data.
- Handles the two cases where metrics that have not been selected can be present in the data:
  - Hidden via the selector
  - Metric was removed via the selector, but since we only removed a metric, we do not make another request to the API
- Changes x-axis ticks to use a format with a short month and numeric year (`Jan 2021`)
- Tries to show a tick every time a new year starts, though Recharts sometimes hides ticks to preserve gaps between ticks
- Makes the metric select element responsive on narrow screens