### PR TITLE
Create _document for Content-Security-Policy and other headers

### DIFF
--- a/app/pages/_document.js
+++ b/app/pages/_document.js
@@ -1,0 +1,70 @@
+/**
+ * Based on Rees Morris' article on CSP in NextJS:
+ * https://reesmorris.co.uk/blog/implementing-proper-csp-nextjs-styled-components
+ */
+
+import { randomBytes } from 'crypto';
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+const generateNonce = () => {
+  return randomBytes(16).toString('base64');
+};
+
+// Return a Content Security Policy string
+const generateCSP = (nonce) => {
+  // Get our origin
+  const apiURL = process.env.NEXT_PUBLIC_API
+  const origin = apiURL.split('://')[1].split(':')[0]
+  
+  // Create and join list of allowed URLs
+  const urls = [
+    'transithealth.herokuapp.com',
+    `${origin}` // TODO: Will this work?
+  ].join(' ')
+  
+  // Define the directives/values
+  const csp = {
+    'default-src': `'none'`,
+    // TODO: Fill in the rest of the Content-Security-Policy directives and values
+  };
+
+  // Override directives outside production
+  if (process.env.NODE_ENV !== 'production') {
+    csp['script-src'] = `'self' 'unsafe-eval' 'nonce-${nonce}'`;
+  }
+
+  // Convert to string and return
+  const header = Object.entries(csp).reduce(
+    (acc, [key, val]) => `${acc} ${key} ${val};`,
+    ''
+  );
+  
+  return header;
+};
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    const nonce = generateNonce();
+    const csp = generateCSP(nonce);
+    return {
+      ...initialProps,
+      nonce,
+      csp,
+    }
+  }
+
+  render() {
+    const { nonce, csp } = this.props;
+    // TODO: Add meta tag for header
+    return (
+      <Html>
+        <Head nonce={nonce} />
+        <body>
+          <Main />
+          <NextScript nonce={nonce} />
+        </body>
+      </Html>
+    )
+  }
+}


### PR DESCRIPTION
NextJS has some struggles related to implementing a Content-Security-Policy.

Long story short, in development NextJS generates and evaluates scripts and styles in an unsafe way. It required some messing around with how our NextJS pages are rendered to add a more secure Content-Security-Policy and keep the current functionality.

For more background, check out these links:

- [GitHub issue on the NextJS repository explaining the challenges](https://github.com/vercel/next.js/issues/256)
- [Article by Rees Morris explaining a workaround](https://reesmorris.co.uk/blog/implementing-proper-csp-nextjs-styled-components)

The [advanced feature in the NextJS documentation](https://nextjs.org/docs/advanced-features/security-headers) did not work. But I was able to use the [`_document.js`](https://nextjs.org/docs/advanced-features/custom-document) page and most of Rees Morris' solution to add the headers. The main change I made, so that the headers would work on our static site in production, was to manually set a meta tag in the Head tag with the header.

Since our site is statically rendered, the nonce will be the same value for each build and available in the source code. I worry that this means attackers can retrieve the nonce and use it to inject a script past the policy. However, I tried to inject a script from a different origin with the same nonce, and it was still rejected by the policy.

I will work with @Jmacias2019 to implement our Content-Security-Policy. Hopefully we can use this approach for the other headers as well.

CC: @olakukielko 