### PR TITLE
Implemented Search for Scatter modal

### DIFF
--- a/app/components/SearchableMetricSelector.js
+++ b/app/components/SearchableMetricSelector.js
@@ -2,10 +2,24 @@ import { useEffect, useState } from 'react'
 
 function Modal(props){
   const { supportedMetrics, onClose, selectMetric, show } = props;
+  const [searchText, setSearchText] = useState("")
   if(!show){
     return null;
   }
-  
+  const searchTextLower = searchText.toLowerCase().trim()
+  const searchResults = searchTextLower.length === 0 
+    ? Object.keys(supportedMetrics)
+    : Object.keys(supportedMetrics)
+      .filter((k) => {
+        const metric = supportedMetrics[k]
+        const metricNameLower = metric.name.toLowerCase()
+      
+        return metricNameLower.indexOf(searchTextLower) > -1
+      })
+  const searchResultsMessage = searchTextLower.length === 0
+    ? "Showing all Metrics"
+    : `Showing results for ${searchText}`
+    
   return (
     <div className="SelectorModal" onClick={onClose} >
         <div className="modal-content" onClick={e => e.stopPropagation() } >
@@ -13,8 +27,19 @@ function Modal(props){
             <h4 className="modal-title">Select your Metric</h4>
           </div>
           <div className="modal-body" >
-            <span>
-              {Object.keys(supportedMetrics).map((k, i) => (
+            <div className="searchBar"> 
+              <p> <input 
+                type="text" 
+                value={searchText} 
+                placeholder="Search Metrics..."
+                onChange={(e) => setSearchText(e.target.value)}
+              /> </p>
+              
+              <p>{searchResultsMessage}</p>
+            
+            </div>
+            <div>
+              {searchResults.map((k, i) => (
                 <p 
                 key={i} 
                 onClick={ () => {
@@ -23,7 +48,7 @@ function Modal(props){
                 } }
                 >{supportedMetrics[k].name}</p>
               ))}
-            </span>
+            </div>
           </div>
           <div className="modal-footer" >
             <button className="closeButton" onClick={onClose} >Close</button>

--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -1,7 +1,7 @@
 /* global fetch */
 
 import { useState, useEffect, useRef } from 'react'
-import { MetricSelector } from '../components/Common'
+import SearchableMetricSelector  from '../components/SearchableMetricSelector'
 import {
   timelineMetrics,
   timelineExplorerDefaults
@@ -195,7 +195,8 @@ function TimelineMetrics({ metrics, setMetrics }) {
         );
       })}
       <div className="MetricEditor">
-        <MetricSelector
+        <SearchableMetricSelector
+          label=""
           supportedMetrics={supportedMetrics}
           defaultValue={defaultMetricToAdd}
           onChange={setMetricToAdd}


### PR DESCRIPTION
Added a new input search bar within the new modal for the Scatter explorer page, as mentioned in #99. Uses live results rather than needing to press search. Also dynamically displays the current search results based on the input text in the search bar. 