### PR TITLE
Modal Metrics Styling

### DIFF
--- a/app/components/SearchableMetricSelector.js
+++ b/app/components/SearchableMetricSelector.js
@@ -21,12 +21,12 @@ function Modal(props){
     : `Showing results for ${searchText}`
     
   return (
-    <div className="SelectorModal" onClick={onClose} >
-        <div className="modal-content" onClick={e => e.stopPropagation() } >
-          <div className="modal-header" >
-            <h4 className="modal-title">Select your Metric</h4>
+    <div className="selectorModal" onClick={onClose} >
+        <div className="modalContent" onClick={e => e.stopPropagation() } >
+          <div className="modalHeader" >
+            <h4 className="modalTitle">Select your Metric</h4>
           </div>
-          <div className="modal-body" >
+          <div className="modalBody" >
             <div className="searchBar"> 
               <p> <input 
                 type="text" 
@@ -50,7 +50,7 @@ function Modal(props){
               ))}
             </div>
           </div>
-          <div className="modal-footer" >
+          <div className="modalFooter" >
             <button className="closeButton" onClick={onClose} >Close</button>
           </div>
         </div>

--- a/app/components/SearchableMetricSelector.js
+++ b/app/components/SearchableMetricSelector.js
@@ -38,7 +38,7 @@ function Modal(props){
               <p>{searchResultsMessage}</p>
             
             </div>
-            <div>
+            <div className="searchResults">
               {searchResults.map((k, i) => (
                 <p 
                 key={i} 

--- a/app/components/SearchableMetricSelector.js
+++ b/app/components/SearchableMetricSelector.js
@@ -64,9 +64,9 @@ export default function SearchableMetricSelector(props) {
   const [selectedMetric, setSelectedMetric] = useState(defaultValue)
   
   return (
-    <div className="SearchableMetricSelector">
+    <div className="searchableMetricSelector">
     
-      <div className="SelectorBody"> 
+      <div className="selectorBody"> 
         { label ? (<span className="bold selectorLabel">{label}: </span>) : null }
         <button className="selectorButton" onClick={() => setShow(1)}>{supportedMetrics[selectedMetric].name}</button>
       </div>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -242,6 +242,11 @@ nav a:hover {
     overflow-y: auto;
 }
 
+.SearchableMetricSelector .searchResults p:hover {
+    background-color: rgba(180, 180, 180, 0.5);
+    cursor: pointer;
+}
+
 .SearchableMetricSelector .modal-header, 
 .SearchableMetricSelector .modal-footer {
     padding: 10px

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -217,7 +217,7 @@ nav a:hover {
     padding-right: 1em;
 }
 
-.SearchableMetricSelector .SelectorModal {
+.SearchableMetricSelector .selectorModal {
     left: 0;
     right: 0;
     top: 0;
@@ -230,12 +230,12 @@ nav a:hover {
     justify-content: center;
 }
 
-.SearchableMetricSelector .modal-content {
+.SearchableMetricSelector .modalContent {
     width: 500px;
     background-color: white;
 }
 
-.SearchableMetricSelector .modal-body {
+.SearchableMetricSelector .modalBody {
     border-top: 1px solid #eee;
     border-bottom: 1px solid #eee;
     max-height: calc(100vh - 210px);
@@ -251,8 +251,8 @@ nav a:hover {
     cursor: pointer;
 }
 
-.SearchableMetricSelector .modal-header, 
-.SearchableMetricSelector .modal-footer {
+.SearchableMetricSelector .modalHeader, 
+.SearchableMetricSelector .modalFooter {
     padding: 10px
 }
 
@@ -272,7 +272,7 @@ nav a:hover {
         display: block;
     }
     
-    .SearchableMetricSelector .modal-content {
+    .SearchableMetricSelector .modalContent {
         width:100%;
     }
     

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -246,6 +246,10 @@ nav a:hover {
     border-bottom: 1px solid #eee;
 }
 
+.SearchableMetricSelector .searchResults p {
+    border-bottom: 1px solid #D3D3D3;
+}
+
 .SearchableMetricSelector .searchResults p:hover {
     background-color: rgba(180, 180, 180, 0.5);
     cursor: pointer;

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -242,6 +242,10 @@ nav a:hover {
     overflow-y: auto;
 }
 
+.SearchableMetricSelector .searchBar {
+    border-bottom: 1px solid #eee;
+}
+
 .SearchableMetricSelector .searchResults p:hover {
     background-color: rgba(180, 180, 180, 0.5);
     cursor: pointer;

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -211,13 +211,13 @@ nav a:hover {
     padding-right: 1em;
 }
 
-.SearchableMetricSelector {
+.searchableMetricSelector {
     display: inline-block;
     padding: 0.5em 0;
     padding-right: 1em;
 }
 
-.SearchableMetricSelector .selectorModal {
+.searchableMetricSelector .selectorModal {
     left: 0;
     right: 0;
     top: 0;
@@ -230,37 +230,37 @@ nav a:hover {
     justify-content: center;
 }
 
-.SearchableMetricSelector .modalContent {
+.searchableMetricSelector .modalContent {
     width: 500px;
     background-color: white;
 }
 
-.SearchableMetricSelector .modalBody {
+.searchableMetricSelector .modalBody {
     border-top: 1px solid #eee;
     border-bottom: 1px solid #eee;
     max-height: calc(100vh - 210px);
     overflow-y: auto;
 }
 
-.SearchableMetricSelector .searchBar {
+.searchableMetricSelector .searchBar {
     border-bottom: 1px solid #eee;
 }
 
-.SearchableMetricSelector .searchResults p {
+.searchableMetricSelector .searchResults p {
     border-bottom: 1px solid #D3D3D3;
 }
 
-.SearchableMetricSelector .searchResults p:hover {
+.searchableMetricSelector .searchResults p:hover {
     background-color: rgba(180, 180, 180, 0.5);
     cursor: pointer;
 }
 
-.SearchableMetricSelector .modalHeader, 
-.SearchableMetricSelector .modalFooter {
+.searchableMetricSelector .modalHeader, 
+.searchableMetricSelector .modalFooter {
     padding: 10px
 }
 
-.SearchableMetricSelector .selectorButton {
+.searchableMetricSelector .selectorButton {
     width: 500px;
     text-align: left;
     text-overflow: ellipsis;
@@ -271,16 +271,16 @@ nav a:hover {
 
 @media screen and (max-width: 500px) {
     
-    .SearchableMetricSelector .selectorButton{
+    .searchableMetricSelector .selectorButton{
         width: calc(100vw - 4em);
         display: block;
     }
     
-    .SearchableMetricSelector .modalContent {
+    .searchableMetricSelector .modalContent {
         width:100%;
     }
     
-    .SearchableMetricSelector .selectorLabel{
+    .searchableMetricSelector .selectorLabel{
         margin: 1em 0;
         display: block;
     }


### PR DESCRIPTION
Small change of styling for each metric under the modal. This should make each one more distinguishable in the UI. Also altered element names to use consistent `className` naming schemes in the `SearchableMetricSelector` file's code.

The Modal Before

![image](https://user-images.githubusercontent.com/72165627/127435701-6896d322-0ee2-4f00-8521-184ab36d6cea.png)


The Modal After

![image](https://user-images.githubusercontent.com/72165627/127435829-e8c1a92c-bd0b-4842-b28d-7fee41b94373.png)
