### PR TITLE
Remove 2000 Total Population Metric

### DIFF
--- a/api/endpoints/community.py
+++ b/api/endpoints/community.py
@@ -21,7 +21,6 @@ def make_blueprint(con):
         "rideshare_pooled_trip_rate_2019": lambda: metric.rideshare_pooled_trip_rate(year=2019),
         "rideshare_pool_request_rate_2018": lambda: metric.rideshare_pool_request_rate(year=2018),
         "rideshare_pool_request_rate_2019": lambda: metric.rideshare_pool_request_rate(year=2019),
-        "total_population_2000": lambda: metric.population(year=2000, segment="all"),
         "total_population_2010": lambda: metric.population(year=2010, segment="all"),
         "total_population_2019": lambda: metric.population(year=2019, segment="all"),
         "median_income_2010": lambda: metric.income(year=2010, segment="all"),

--- a/app/site/metrics.js
+++ b/app/site/metrics.js
@@ -49,12 +49,6 @@ export const communityMetrics = {
     format: Formatter.percentWithNoDecimal,
     fullFormat: Formatter.percentWithOneDecimal,
   },
-  total_population_2000: {
-    name: "2000 Total Population",
-    units: "people",
-    format: Formatter.numberInThousands,
-    fullFormat: Formatter.numberWithCommas,
-  },
   total_population_2010: {
     name: "2010 Total Population",
     units: "people",


### PR DESCRIPTION
During some testing of the new modal's UI on a mobile platform, I noticed that choosing the `2000 Total Population` metric on the app resulted in an empty scatter plot and a fully opaque map. Logging the value of the data in the code showed that no Population data was being returned. This can be seen below

![image](https://user-images.githubusercontent.com/72165627/127543269-fea8753f-458b-4370-a3d9-c486410a9115.png)

It was a bit unclear why this was the case, so I did some further testing by pulling the latest for main and running `run pipeline-quick`. After a quick check of the database using SQLite, using the query 
```SQL
SELECT MAX(value), period_end_year
FROM population
GROUP By period_end_year
```

It returned data for years from 2010 to 2019.

![image](https://user-images.githubusercontent.com/72165627/127543702-4b6ec3dd-1b97-412b-aa16-783b57477621.png)

I also went ahead and double-checked the Chicago Health Atlas API, and it appears the data for the year 2000 was removed at some point.

I asked @vingkan about the best solution and we've decided to simply remove this particular metric. The 2010 and 2019 Total Population metrics remain unchanged and work as intended.