### PR TITLE
Corrected Modal Grouping Behavior

### DIFF
--- a/app/components/SearchableMetricSelector.js
+++ b/app/components/SearchableMetricSelector.js
@@ -15,15 +15,15 @@ function sortDictionary(dictionary){
   }
   
 //Create a dictionary of all unique tags/datasets that exist, each key holding an array of metrics belonging to that tag/dataset
-function createTagDictionary(supportedMetrics){
+function createTagDictionary(supportedMetrics, searchResults){
   const groups = [...new Set(Object.keys(supportedMetrics).map(q => supportedMetrics[q].dataset))];
-  const metricRecords = Object.keys(supportedMetrics)
+  const metricRecords = searchResults
   var tagDictionary = {};
   
   for (var i in groups){
     var groupedRecords = [];
-    for(var j in Object.keys(supportedMetrics)){
-      var record = Object.keys(supportedMetrics)[j]
+    for(var j in searchResults){
+      var record = searchResults[j]
       if(groups[i] === supportedMetrics[record].dataset){
         groupedRecords.push(metricRecords[j])
       }
@@ -142,7 +142,7 @@ function GroupedMetricSearchResults(props){
   const searchTextLower = searchText.toLowerCase().trim()
   const searchResults = filterSearchResults(supportedMetrics, searchText)
   
-  var tagDictionary = createTagDictionary(supportedMetrics);
+  var tagDictionary = createTagDictionary(supportedMetrics, searchResults);
   var tagDictArray = createDictArray(tagDictionary);
   tagDictArray = sortDictionary(tagDictionary)
 


### PR DESCRIPTION
Applies a fix in regards to #153. Previous behavior was not necessarily a bug, but was a product of when the tag dictionary was sorted. Now the dictionary and groups are sorted based on the current search text rather than all possible metrics. 

The new behavior can be seen below.

![image](https://user-images.githubusercontent.com/72165627/127787175-d4e00519-3a7f-4a58-83f8-e6325ca5dcc2.png)
