### PR TITLE
Fix bug where removing metrics from timeline view then adding metrics causes an error.

### DIFF
--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -94,8 +94,17 @@ function TimelineChart({ data, metrics }) {
   const selectedMetricIds = metrics
     .filter(m => m.axis !== "none")
     .map(m => m.id);
+    
+  const dataWithSelectedMetric = data
+    .filter((d) => (
+        selectedMetricIds.filter(m => m in d).length > 0
+      ));
   
-  if (data?.length === 0 || selectedMetricIds.length === 0) return null;
+  if (data?.length === 0 ||
+      selectedMetricIds.length === 0 ||
+      dataWithSelectedMetric.length == 0) {
+    return null;
+  }
 
   const chartData = data
     // Only keep dates with values for selected metrics


### PR DESCRIPTION
Fixes #147 

Very similar root cause and fix as in #103 

**Root Cause:** Timeline view tries to render as soon as the selected metrics change, but the data has not yet arrived, causing an error when it tries to format metrics it does not have yet.

**Solution:** Skip render if no selected metrics are in the data. When the response comes, the timeline chart will be able to render the new metrics.

Recording showing the fix in action:

https://www.loom.com/share/07ae403b62e14115bfd1d9c3886bb16c