### PR TITLE
Connect all points of a metric series, even if dates are missing

### DIFF
--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -94,8 +94,17 @@ function TimelineChart({ data, metrics }) {
   const selectedMetricIds = metrics
     .filter(m => m.axis !== "none")
     .map(m => m.id);
+    
+  const dataWithSelectedMetric = data
+    .filter((d) => (
+        selectedMetricIds.filter(m => m in d).length > 0
+      ));
   
-  if (data?.length === 0 || selectedMetricIds.length === 0) return null;
+  if (data?.length === 0 ||
+      selectedMetricIds.length === 0 ||
+      dataWithSelectedMetric.length == 0) {
+    return null;
+  }
 
   const chartData = data
     // Only keep dates with values for selected metrics

--- a/app/components/TimelineExplorer.js
+++ b/app/components/TimelineExplorer.js
@@ -150,7 +150,14 @@ function TimelineChart({ data, metrics }) {
         {metrics.filter((m) => m.axis !== "none").map((m, i) => {
           const color = m.color || defaultColors[i % defaultColors.length];
           return (
-            <Area key={`${i}-${m.id}`} yAxisId={m.axis} dataKey={m.id} stroke={color} fill={color} />
+            <Area
+              key={`${i}-${m.id}`}
+              yAxisId={m.axis}
+              dataKey={m.id}
+              stroke={color}
+              fill={color}
+              connectNulls={true}
+            />
           );
         })}
         <Tooltip content={ <CustomToolTip metrics={metrics} /> } />


### PR DESCRIPTION
Fixes #159 

**Root Cause:** When displaying metrics of different time intervals, Recharts groups data by date and considers dates that don't have a value to be null, creating a gap between points.

**Solution:** Set `connectNulls={true}` to always connect subsequent data points in a series.

**Caveats:** This has the drawback that if a series actually has a null gap in its data, the gap will be connected. We should make sure that any null values are set to zero or another logical value.

Screenshot before (bug):

<img width="1194" alt="Screen Shot 2021-08-01 at 7 49 24 PM" src="https://user-images.githubusercontent.com/11896652/127790941-02f2fad5-92a6-4280-afba-d9cf94c459da.png">

Screenshot after (fix):

<img width="1194" alt="Screen Shot 2021-08-01 at 7 48 31 PM" src="https://user-images.githubusercontent.com/11896652/127790951-e0970b66-6a50-4bed-b0ca-7e2b1190644a.png">