### PR TITLE
home page now display insights with functioning search

### DIFF
--- a/app/components/InsightSearch.js
+++ b/app/components/InsightSearch.js
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { insights } from '../site/insights'
+
+const INSIGHT_TYPE = {
+  scatter : {
+    name : "Scatter Plot"
+  }
+}
+
+
+export default function InsightSearch(){
+  const [searchText, setSearchText] = useState('');
+  const searchTextLower = searchText.toLowerCase();
+  const results = insights.filter((d) => {
+    const nameLower = d.name.toLowerCase();
+    return nameLower.indexOf(searchTextLower) > -1;
+  });
+  const resultsMessage = searchText
+    ? results.length > 0
+      ? `Showing ${results.length} Results for ${searchText}`
+      : `No Results for ${searchText}`
+    : "Showing All Results";
+  return (
+    <div className="insightsSearch left medium-width">
+      <div className="searchBar">
+        <input
+          type="text"
+          placeholder="What do you want to know about?"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+        />
+        <p>{resultsMessage}</p>
+      </div>
+      <div className ="searchResultContainer">
+        {results.map((d) => {
+          const url = `/scatter?x=${d.x}&y=${d.y}`
+          const config = INSIGHT_TYPE[d.type]
+          return (
+            <div className="searchResult">
+              <h3>{d.name}</h3>
+              <p>{config.name}</p>
+              <Link href={url}>
+                <a className="btn secondary">View Insight</a>
+              </Link>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/pages/index.js
+++ b/app/pages/index.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Nav from '../components/Nav'
 import { ServerLoadingNotification } from '../components/Notification'
+import InsightSearch from '../components/InsightSearch'
 
 export default function Home() {
   return (
@@ -20,7 +21,7 @@ export default function Home() {
           </div>
           <br />
           <div className="center">
-            <p>New home page content coming soon...</p>
+            <InsightSearch />
           </div>
         </div>
       </main>

--- a/app/site/insights.js
+++ b/app/site/insights.js
@@ -8,7 +8,7 @@ export const insights = [
   {
     name: "COVID Rates by Community Rate of Belonging",
     type: "scatter",
-    x: "yearly_belonging_rate_all",
+    x: "belonging_rate_2018",
     y: "total_covid_cases",
   },
   {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -369,6 +369,12 @@ a.btn {
     text-decoration: none;
 }
 
+/* Home Page Search*/
+/*TODO: Maria add styles for search here */
+/*.insightsSearch{*/
+    
+/*}*/
+
 /* Plots */
 
 .PlotRow div {


### PR DESCRIPTION
Clicking on "view insight" takes user to corresponding page (scatter plot) with set x and y axis
![image](https://user-images.githubusercontent.com/36111703/128570892-2ab9c956-38af-4246-8888-203b4a38882d.png)
