### PR TITLE
Fix for Modal Closing when Input is Focused

### DIFF
--- a/app/components/SearchableMetricSelector.js
+++ b/app/components/SearchableMetricSelector.js
@@ -66,6 +66,8 @@ function filterSearchResults(supportedMetrics, searchText){
 function Modal(props){
   const { supportedMetrics, onClose, selectMetric, show } = props;
   const [searchText, setSearchText] = useState("")
+  const [focus, setFocus] = useState(0)
+  console.log(focus)
   if(!show){
     return null;
   }
@@ -78,7 +80,7 @@ function Modal(props){
     
   
   return (
-    <div className="selectorModal" onClick={onClose} >
+    <div className="selectorModal" {...(!focus && { onClick: {onClose} })} >
         <div className="modalContent" onClick={e => e.stopPropagation() } >
           <div className="modalHeader" >
             <h4 className="modalTitle">Select your Metric</h4>
@@ -90,6 +92,8 @@ function Modal(props){
                 value={searchText} 
                 placeholder="Search Metrics..."
                 onChange={(e) => setSearchText(e.target.value)}
+                onFocus={() => setFocus(1)}
+                onBlur={() => setFocus(0)}
               /> </p>
               
               <p>{searchResultsMessage}</p>

--- a/app/components/SearchableMetricSelector.js
+++ b/app/components/SearchableMetricSelector.js
@@ -67,7 +67,7 @@ function Modal(props){
   const { supportedMetrics, onClose, selectMetric, show } = props;
   const [searchText, setSearchText] = useState("")
   const [focus, setFocus] = useState(0)
-  console.log(focus)
+  
   if(!show){
     return null;
   }

--- a/app/components/SearchableMetricSelector.js
+++ b/app/components/SearchableMetricSelector.js
@@ -80,7 +80,7 @@ function Modal(props){
     
   
   return (
-    <div className="selectorModal" {...(!focus && { onClick: {onClose} })} >
+    <div className="selectorModal" onClick={focus ? undefined : onClose} >
         <div className="modalContent" onClick={e => e.stopPropagation() } >
           <div className="modalHeader" >
             <h4 className="modalTitle">Select your Metric</h4>


### PR DESCRIPTION
This should apply a fix for #160, the modal now checks if the Input is being focused or not. 

It seems this solution 

```javascript
onClick={focus ? undefined : onClose}
``` 

will work, although I'm not sure if there is a better way of doing this. Opinions or feedback on this would be great.