### PR TITLE
Minor Searchbar Cosmetic Fix

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -249,6 +249,7 @@ input {
 
 .searchableMetricSelector .searchBar {
     border-bottom: 1px solid #eee;
+    border-top: 1px solid #fff;
     position: sticky;
     top: 0;
     background-color: white;


### PR DESCRIPTION
Provides a very small fix to the CSS Styling for the modal's search bar, small bits of text will no longer be visible above the search.

Example of what the search bar looked like before:

![image](https://user-images.githubusercontent.com/72165627/129977065-5d60466f-2c36-4b82-b02b-f7777f274bea.png)


And with the fix applied:

![image](https://user-images.githubusercontent.com/72165627/129977135-4b485f94-6b58-4b54-91c4-161c1c37a99a.png)


The issue still persists on some mobile devices, but it's difficult to account for all screen sizes. This was mostly a small nitpick I decided to fix.